### PR TITLE
Feature/164699431 add carousel species summary

### DIFF
--- a/__mocks__/matchMedia.js
+++ b/__mocks__/matchMedia.js
@@ -1,6 +1,4 @@
-'use strict'
-
-Object.defineProperty(window, 'matchMedia', {
+Object.defineProperty(window, `matchMedia`, {
   value: () => ({
     matches: false,
     addListener: () => {},

--- a/__test__/SpeciesSummaryPanel.test.js
+++ b/__test__/SpeciesSummaryPanel.test.js
@@ -8,12 +8,27 @@ describe(`SpeciesSummaryPanel`, () => {
     expect(shallow(
       <SpeciesSummaryPanel
         speciesSummary={[]}
+        carouselCardsRowProps={{
+          className: `row expanded small-up-2 medium-up-3 large-up-6`,
+          cardContainerClassName: `column`,
+          sliderSettings: {slidesToShow: 2},
+          containerHeight: `320px`,
+          sliderHeight: `300px`
+        }
+        }
         onComponentDidMount={done}/>
     ))
   })
 
   test(`renders correctly`, () => {
-    expect(mount(<SpeciesSummaryPanel {...speciesSummary}/>)).toMatchSnapshot()
-    expect(mount(<SpeciesSummaryPanel speciesSummary={[]}/>)).toMatchSnapshot()
+    const carouselCardsRowProps={
+      className: `row expanded small-up-2 medium-up-3 large-up-6`,
+      cardContainerClassName: `column`,
+      sliderSettings: {slidesToShow: 2},
+      containerHeight: `320px`,
+      sliderHeight: `300px`
+    }
+    expect(mount(<SpeciesSummaryPanel {...speciesSummary} carouselCardsRowProps={carouselCardsRowProps}/>)).toMatchSnapshot()
+    expect(mount(<SpeciesSummaryPanel speciesSummary={[]} carouselCardsRowProps={carouselCardsRowProps}/>)).toMatchSnapshot()
   })
 })

--- a/__test__/SpeciesSummaryPanel.test.js
+++ b/__test__/SpeciesSummaryPanel.test.js
@@ -1,3 +1,5 @@
+import matchMedia from './matchMedia' // Must be imported before the tested file
+
 import SpeciesSummaryPanel from '../src/SpeciesSummaryPanel'
 import { shallow, mount } from 'enzyme'
 

--- a/__test__/SpeciesSummaryPanel.test.js
+++ b/__test__/SpeciesSummaryPanel.test.js
@@ -1,5 +1,3 @@
-import matchMedia from './matchMedia' // Must be imported before the tested file
-
 import SpeciesSummaryPanel from '../src/SpeciesSummaryPanel'
 import { shallow, mount } from 'enzyme'
 

--- a/__test__/__snapshots__/SpeciesSummaryPanel.test.js.snap
+++ b/__test__/__snapshots__/SpeciesSummaryPanel.test.js.snap
@@ -391,1315 +391,955 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
       >
         <div
           className=""
+          style={
+            Object {
+              "height": "350px",
+              "padding": "inherit",
+            }
+          }
         >
-          <GlobalStyleComponent />
-          <Slider
-            autoplay={true}
-            autoplaySpeed={2000}
-            dots={true}
-            infinite={true}
-            slidesToScroll={1}
-            slidesToShow={6}
-            speed={500}
+          <styled.div
+            className=""
+            key="0"
           >
-            <InnerSlider
-              accessibility={true}
-              adaptiveHeight={false}
-              afterChange={null}
-              appendDots={[Function]}
-              arrows={true}
-              autoplay={true}
-              autoplaySpeed={2000}
-              beforeChange={null}
-              centerMode={false}
-              centerPadding="50px"
+            <StyledComponent
               className=""
-              cssEase="ease"
-              customPaging={[Function]}
-              dots={true}
-              dotsClass="slick-dots"
-              draggable={true}
-              easing="linear"
-              edgeFriction={0.35}
-              fade={false}
-              focusOnSelect={false}
-              infinite={true}
-              initialSlide={0}
-              lazyLoad={null}
-              nextArrow={null}
-              onEdge={null}
-              onInit={null}
-              onLazyLoadError={null}
-              onReInit={null}
-              pauseOnDotsHover={false}
-              pauseOnFocus={false}
-              pauseOnHover={true}
-              prevArrow={null}
-              responsive={null}
-              rows={1}
-              rtl={false}
-              slide="div"
-              slidesPerRow={1}
-              slidesToScroll={1}
-              slidesToShow={6}
-              speed={500}
-              swipe={true}
-              swipeEvent={null}
-              swipeToSlide={false}
-              touchMove={true}
-              touchThreshold={5}
-              unslick={true}
-              useCSS={true}
-              useTransform={true}
-              variableWidth={false}
-              vertical={false}
-              waitForAnimate={true}
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-bxivhb",
+                    "isStatic": true,
+                    "lastClassName": "gxCHar",
+                    "rules": Array [
+                      "
+    :hover {
+      background: ",
+                      "AliceBlue",
+                      ";
+    }
+  ",
+                    ],
+                  },
+                  "displayName": "styled.div",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "sc-bxivhb",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
             >
               <div
-                className="slick-slider slick-initialized"
+                className="sc-bxivhb gxCHar"
               >
-                <div
-                  className="slick-list"
-                >
-                  <Track
-                    centerMode={false}
-                    centerPadding="50px"
-                    cssEase="ease"
-                    currentSlide={0}
-                    fade={false}
-                    focusOnSelect={null}
-                    infinite={true}
-                    lazyLoad={null}
-                    lazyLoadedList={Array []}
-                    listHeight={0}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                    rtl={false}
-                    slideCount={6}
-                    slideHeight={0}
-                    slideWidth={0}
-                    slidesToScroll={1}
-                    slidesToShow={6}
-                    speed={500}
-                    trackStyle={
+                <Card
+                  content={
+                    Array [
                       Object {
-                        "WebkitTransform": "translate3d(0px, 0px, 0px)",
-                        "WebkitTransition": "",
-                        "msTransform": "translateX(0px)",
-                        "opacity": 1,
-                        "transform": "translate3d(0px, 0px, 0px)",
-                        "transition": "",
+                        "text": "10 experiments",
+                      },
+                      Object {
+                        "text": "Baseline: 7",
+                        "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=baseline",
+                      },
+                      Object {
+                        "text": "Differential: 3",
+                        "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=differential",
+                      },
+                    ]
+                  }
+                  description={
+                    Object {
+                      "text": "Homo sapiens",
+                      "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens",
+                    }
+                  }
+                  iconSrc="homo sapiens"
+                  iconType="species"
+                  imageIconHeight="2rem"
+                  speciesIconHeight="6rem"
+                >
+                  <div
+                    style={
+                      Object {
+                        "marginBottom": 0,
+                        "paddingBottom": "2rem",
+                        "textAlign": "center",
                       }
                     }
-                    unslick={true}
-                    variableWidth={false}
-                    vertical={false}
                   >
-                    <div
-                      className="slick-track"
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseOver={[Function]}
+                    <a
+                      href="http://localhost:8080/gxa/experiments?species=homo%20sapiens"
                       style={
                         Object {
-                          "WebkitTransform": "translate3d(0px, 0px, 0px)",
-                          "WebkitTransition": "",
-                          "msTransform": "translateX(0px)",
-                          "opacity": 1,
-                          "transform": "translate3d(0px, 0px, 0px)",
-                          "transition": "",
+                          "borderBottom": 0,
                         }
                       }
                     >
-                      <div
-                        aria-hidden={false}
-                        className="slick-slide slick-active slick-current"
-                        data-index={0}
-                        key="original0"
-                        onClick={[Function]}
+                      <span
                         style={
                           Object {
-                            "outline": "none",
-                            "width": 0,
+                            "fontSize": "6rem",
                           }
                         }
-                        tabIndex="-1"
                       >
-                        <div
-                          key="0"
+                        <EbiSpeciesIcon
+                          groupColors={
+                            Object {
+                              "other": "deepskyblue",
+                              "plants": "mediumseagreen",
+                              "warmBlooded": "indianred",
+                            }
+                          }
+                          species="homo sapiens"
                         >
-                          <styled.div
-                            className=""
-                            key="0"
+                          <span
+                            className="icon icon-species"
+                            data-icon="H"
                             style={
                               Object {
-                                "display": "inline-block",
-                                "width": "100%",
+                                "color": "indianred",
                               }
                             }
-                            tabIndex={-1}
-                          >
-                            <StyledComponent
-                              className=""
-                              forwardedComponent={
-                                Object {
-                                  "$$typeof": Symbol(react.forward_ref),
-                                  "attrs": Array [],
-                                  "componentStyle": ComponentStyle {
-                                    "componentId": "sc-bxivhb",
-                                    "isStatic": true,
-                                    "lastClassName": "gxCHar",
-                                    "rules": Array [
-                                      "
-    :hover {
-      background: ",
-                                      "AliceBlue",
-                                      ";
-    }
-  ",
-                                    ],
-                                  },
-                                  "displayName": "styled.div",
-                                  "foldedComponentIds": Array [],
-                                  "render": [Function],
-                                  "styledComponentId": "sc-bxivhb",
-                                  "target": "div",
-                                  "toString": [Function],
-                                  "warnTooManyClasses": [Function],
-                                  "withComponent": [Function],
-                                }
-                              }
-                              forwardedRef={null}
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "width": "100%",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <div
-                                className="sc-bxivhb gxCHar"
-                                style={
-                                  Object {
-                                    "display": "inline-block",
-                                    "width": "100%",
-                                  }
-                                }
-                                tabIndex={-1}
-                              >
-                                <Card
-                                  content={
-                                    Array [
-                                      Object {
-                                        "text": "10 experiments",
-                                      },
-                                      Object {
-                                        "text": "Baseline: 7",
-                                        "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=baseline",
-                                      },
-                                      Object {
-                                        "text": "Differential: 3",
-                                        "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=differential",
-                                      },
-                                    ]
-                                  }
-                                  description={
-                                    Object {
-                                      "text": "Homo sapiens",
-                                      "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens",
-                                    }
-                                  }
-                                  iconSrc="homo sapiens"
-                                  iconType="species"
-                                  imageIconHeight="2rem"
-                                  speciesIconHeight="6rem"
-                                >
-                                  <div
-                                    style={
-                                      Object {
-                                        "marginBottom": 0,
-                                        "paddingBottom": "2rem",
-                                        "textAlign": "center",
-                                      }
-                                    }
-                                  >
-                                    <a
-                                      href="http://localhost:8080/gxa/experiments?species=homo%20sapiens"
-                                      style={
-                                        Object {
-                                          "borderBottom": 0,
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        style={
-                                          Object {
-                                            "fontSize": "6rem",
-                                          }
-                                        }
-                                      >
-                                        <EbiSpeciesIcon
-                                          groupColors={
-                                            Object {
-                                              "other": "deepskyblue",
-                                              "plants": "mediumseagreen",
-                                              "warmBlooded": "indianred",
-                                            }
-                                          }
-                                          species="homo sapiens"
-                                        >
-                                          <span
-                                            className="icon icon-species"
-                                            data-icon="H"
-                                            style={
-                                              Object {
-                                                "color": "indianred",
-                                              }
-                                            }
-                                            title="Homo sapiens"
-                                          />
-                                        </EbiSpeciesIcon>
-                                      </span>
-                                    </a>
-                                    <h5>
-                                      <a
-                                        href="http://localhost:8080/gxa/experiments?species=homo%20sapiens"
-                                      >
-                                        Homo sapiens
-                                      </a>
-                                    </h5>
-                                    <ul
-                                      style={
-                                        Object {
-                                          "listStyle": "none",
-                                          "marginLeft": 0,
-                                        }
-                                      }
-                                    >
-                                      <li
-                                        key="10 experiments-0"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        10 experiments
-                                      </li>
-                                      <li
-                                        key="Baseline: 7-1"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        <a
-                                          href="http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=baseline"
-                                        >
-                                          Baseline: 7
-                                        </a>
-                                      </li>
-                                      <li
-                                        key="Differential: 3-2"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        <a
-                                          href="http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=differential"
-                                        >
-                                          Differential: 3
-                                        </a>
-                                      </li>
-                                    </ul>
-                                  </div>
-                                </Card>
-                              </div>
-                            </StyledComponent>
-                          </styled.div>
-                        </div>
-                      </div>
-                      <div
-                        aria-hidden={false}
-                        className="slick-slide slick-active"
-                        data-index={1}
-                        key="original1"
-                        onClick={[Function]}
+                            title="Homo sapiens"
+                          />
+                        </EbiSpeciesIcon>
+                      </span>
+                    </a>
+                    <h5>
+                      <a
+                        href="http://localhost:8080/gxa/experiments?species=homo%20sapiens"
+                      >
+                        Homo sapiens
+                      </a>
+                    </h5>
+                    <ul
+                      style={
+                        Object {
+                          "listStyle": "none",
+                          "marginLeft": 0,
+                        }
+                      }
+                    >
+                      <li
+                        key="10 experiments-0"
                         style={
                           Object {
-                            "outline": "none",
-                            "width": 0,
+                            "marginBottom": "0.3rem",
                           }
                         }
-                        tabIndex="-1"
                       >
-                        <div
-                          key="11"
-                        >
-                          <styled.div
-                            className=""
-                            key="111"
-                            style={
-                              Object {
-                                "display": "inline-block",
-                                "width": "100%",
-                              }
-                            }
-                            tabIndex={-1}
-                          >
-                            <StyledComponent
-                              className=""
-                              forwardedComponent={
-                                Object {
-                                  "$$typeof": Symbol(react.forward_ref),
-                                  "attrs": Array [],
-                                  "componentStyle": ComponentStyle {
-                                    "componentId": "sc-bxivhb",
-                                    "isStatic": true,
-                                    "lastClassName": "gxCHar",
-                                    "rules": Array [
-                                      "
-    :hover {
-      background: ",
-                                      "AliceBlue",
-                                      ";
-    }
-  ",
-                                    ],
-                                  },
-                                  "displayName": "styled.div",
-                                  "foldedComponentIds": Array [],
-                                  "render": [Function],
-                                  "styledComponentId": "sc-bxivhb",
-                                  "target": "div",
-                                  "toString": [Function],
-                                  "warnTooManyClasses": [Function],
-                                  "withComponent": [Function],
-                                }
-                              }
-                              forwardedRef={null}
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "width": "100%",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <div
-                                className="sc-bxivhb gxCHar"
-                                style={
-                                  Object {
-                                    "display": "inline-block",
-                                    "width": "100%",
-                                  }
-                                }
-                                tabIndex={-1}
-                              >
-                                <Card
-                                  content={
-                                    Array [
-                                      Object {
-                                        "text": "2 experiments",
-                                      },
-                                      Object {
-                                        "text": "Differential: 2",
-                                        "url": "http://localhost:8080/gxa/experiments?species=mus%20musculus&experimentType=differential",
-                                      },
-                                    ]
-                                  }
-                                  description={
-                                    Object {
-                                      "text": "Mus musculus",
-                                      "url": "http://localhost:8080/gxa/experiments?species=mus%20musculus",
-                                    }
-                                  }
-                                  iconSrc="mus musculus"
-                                  iconType="species"
-                                  imageIconHeight="2rem"
-                                  speciesIconHeight="6rem"
-                                >
-                                  <div
-                                    style={
-                                      Object {
-                                        "marginBottom": 0,
-                                        "paddingBottom": "2rem",
-                                        "textAlign": "center",
-                                      }
-                                    }
-                                  >
-                                    <a
-                                      href="http://localhost:8080/gxa/experiments?species=mus%20musculus"
-                                      style={
-                                        Object {
-                                          "borderBottom": 0,
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        style={
-                                          Object {
-                                            "fontSize": "6rem",
-                                          }
-                                        }
-                                      >
-                                        <EbiSpeciesIcon
-                                          groupColors={
-                                            Object {
-                                              "other": "deepskyblue",
-                                              "plants": "mediumseagreen",
-                                              "warmBlooded": "indianred",
-                                            }
-                                          }
-                                          species="mus musculus"
-                                        >
-                                          <span
-                                            className="icon icon-species"
-                                            data-icon="M"
-                                            style={
-                                              Object {
-                                                "color": "indianred",
-                                              }
-                                            }
-                                            title="Mus musculus"
-                                          />
-                                        </EbiSpeciesIcon>
-                                      </span>
-                                    </a>
-                                    <h5>
-                                      <a
-                                        href="http://localhost:8080/gxa/experiments?species=mus%20musculus"
-                                      >
-                                        Mus musculus
-                                      </a>
-                                    </h5>
-                                    <ul
-                                      style={
-                                        Object {
-                                          "listStyle": "none",
-                                          "marginLeft": 0,
-                                        }
-                                      }
-                                    >
-                                      <li
-                                        key="2 experiments-0"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        2 experiments
-                                      </li>
-                                      <li
-                                        key="Differential: 2-1"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        <a
-                                          href="http://localhost:8080/gxa/experiments?species=mus%20musculus&experimentType=differential"
-                                        >
-                                          Differential: 2
-                                        </a>
-                                      </li>
-                                    </ul>
-                                  </div>
-                                </Card>
-                              </div>
-                            </StyledComponent>
-                          </styled.div>
-                        </div>
-                      </div>
-                      <div
-                        aria-hidden={false}
-                        className="slick-slide slick-active"
-                        data-index={2}
-                        key="original2"
-                        onClick={[Function]}
+                        10 experiments
+                      </li>
+                      <li
+                        key="Baseline: 7-1"
                         style={
                           Object {
-                            "outline": "none",
-                            "width": 0,
+                            "marginBottom": "0.3rem",
                           }
                         }
-                        tabIndex="-1"
                       >
-                        <div
-                          key="22"
+                        <a
+                          href="http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=baseline"
                         >
-                          <styled.div
-                            className=""
-                            key="222"
-                            style={
-                              Object {
-                                "display": "inline-block",
-                                "width": "100%",
-                              }
-                            }
-                            tabIndex={-1}
-                          >
-                            <StyledComponent
-                              className=""
-                              forwardedComponent={
-                                Object {
-                                  "$$typeof": Symbol(react.forward_ref),
-                                  "attrs": Array [],
-                                  "componentStyle": ComponentStyle {
-                                    "componentId": "sc-bxivhb",
-                                    "isStatic": true,
-                                    "lastClassName": "gxCHar",
-                                    "rules": Array [
-                                      "
-    :hover {
-      background: ",
-                                      "AliceBlue",
-                                      ";
-    }
-  ",
-                                    ],
-                                  },
-                                  "displayName": "styled.div",
-                                  "foldedComponentIds": Array [],
-                                  "render": [Function],
-                                  "styledComponentId": "sc-bxivhb",
-                                  "target": "div",
-                                  "toString": [Function],
-                                  "warnTooManyClasses": [Function],
-                                  "withComponent": [Function],
-                                }
-                              }
-                              forwardedRef={null}
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "width": "100%",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <div
-                                className="sc-bxivhb gxCHar"
-                                style={
-                                  Object {
-                                    "display": "inline-block",
-                                    "width": "100%",
-                                  }
-                                }
-                                tabIndex={-1}
-                              >
-                                <Card
-                                  content={
-                                    Array [
-                                      Object {
-                                        "text": "1 experiment",
-                                      },
-                                      Object {
-                                        "text": "Baseline: 1",
-                                        "url": "http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni&experimentType=baseline",
-                                      },
-                                    ]
-                                  }
-                                  description={
-                                    Object {
-                                      "text": "Schistosoma mansoni",
-                                      "url": "http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni",
-                                    }
-                                  }
-                                  iconSrc="schistosoma mansoni"
-                                  iconType="species"
-                                  imageIconHeight="2rem"
-                                  speciesIconHeight="6rem"
-                                >
-                                  <div
-                                    style={
-                                      Object {
-                                        "marginBottom": 0,
-                                        "paddingBottom": "2rem",
-                                        "textAlign": "center",
-                                      }
-                                    }
-                                  >
-                                    <a
-                                      href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni"
-                                      style={
-                                        Object {
-                                          "borderBottom": 0,
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        style={
-                                          Object {
-                                            "fontSize": "6rem",
-                                          }
-                                        }
-                                      >
-                                        <EbiSpeciesIcon
-                                          groupColors={
-                                            Object {
-                                              "other": "deepskyblue",
-                                              "plants": "mediumseagreen",
-                                              "warmBlooded": "indianred",
-                                            }
-                                          }
-                                          species="schistosoma mansoni"
-                                        >
-                                          <span
-                                            className="icon icon-species"
-                                            data-icon="W"
-                                            style={
-                                              Object {
-                                                "color": "deepskyblue",
-                                              }
-                                            }
-                                            title="Schistosoma mansoni"
-                                          />
-                                        </EbiSpeciesIcon>
-                                      </span>
-                                    </a>
-                                    <h5>
-                                      <a
-                                        href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni"
-                                      >
-                                        Schistosoma mansoni
-                                      </a>
-                                    </h5>
-                                    <ul
-                                      style={
-                                        Object {
-                                          "listStyle": "none",
-                                          "marginLeft": 0,
-                                        }
-                                      }
-                                    >
-                                      <li
-                                        key="1 experiment-0"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        1 experiment
-                                      </li>
-                                      <li
-                                        key="Baseline: 1-1"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        <a
-                                          href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni&experimentType=baseline"
-                                        >
-                                          Baseline: 1
-                                        </a>
-                                      </li>
-                                    </ul>
-                                  </div>
-                                </Card>
-                              </div>
-                            </StyledComponent>
-                          </styled.div>
-                        </div>
-                      </div>
-                      <div
-                        aria-hidden={false}
-                        className="slick-slide slick-active"
-                        data-index={3}
-                        key="original3"
-                        onClick={[Function]}
+                          Baseline: 7
+                        </a>
+                      </li>
+                      <li
+                        key="Differential: 3-2"
                         style={
                           Object {
-                            "outline": "none",
-                            "width": 0,
+                            "marginBottom": "0.3rem",
                           }
                         }
-                        tabIndex="-1"
                       >
-                        <div
-                          key="33"
+                        <a
+                          href="http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=differential"
                         >
-                          <styled.div
-                            className=""
-                            key="333"
-                            style={
-                              Object {
-                                "display": "inline-block",
-                                "width": "100%",
-                              }
-                            }
-                            tabIndex={-1}
-                          >
-                            <StyledComponent
-                              className=""
-                              forwardedComponent={
-                                Object {
-                                  "$$typeof": Symbol(react.forward_ref),
-                                  "attrs": Array [],
-                                  "componentStyle": ComponentStyle {
-                                    "componentId": "sc-bxivhb",
-                                    "isStatic": true,
-                                    "lastClassName": "gxCHar",
-                                    "rules": Array [
-                                      "
-    :hover {
-      background: ",
-                                      "AliceBlue",
-                                      ";
-    }
-  ",
-                                    ],
-                                  },
-                                  "displayName": "styled.div",
-                                  "foldedComponentIds": Array [],
-                                  "render": [Function],
-                                  "styledComponentId": "sc-bxivhb",
-                                  "target": "div",
-                                  "toString": [Function],
-                                  "warnTooManyClasses": [Function],
-                                  "withComponent": [Function],
-                                }
-                              }
-                              forwardedRef={null}
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "width": "100%",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <div
-                                className="sc-bxivhb gxCHar"
-                                style={
-                                  Object {
-                                    "display": "inline-block",
-                                    "width": "100%",
-                                  }
-                                }
-                                tabIndex={-1}
-                              >
-                                <Card
-                                  content={
-                                    Array [
-                                      Object {
-                                        "text": "1 experiment",
-                                      },
-                                      Object {
-                                        "text": "Differential: 1",
-                                        "url": "http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster&experimentType=differential",
-                                      },
-                                    ]
-                                  }
-                                  description={
-                                    Object {
-                                      "text": "Drosophila melanogaster",
-                                      "url": "http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster",
-                                    }
-                                  }
-                                  iconSrc="drosophila melanogaster"
-                                  iconType="species"
-                                  imageIconHeight="2rem"
-                                  speciesIconHeight="6rem"
-                                >
-                                  <div
-                                    style={
-                                      Object {
-                                        "marginBottom": 0,
-                                        "paddingBottom": "2rem",
-                                        "textAlign": "center",
-                                      }
-                                    }
-                                  >
-                                    <a
-                                      href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster"
-                                      style={
-                                        Object {
-                                          "borderBottom": 0,
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        style={
-                                          Object {
-                                            "fontSize": "6rem",
-                                          }
-                                        }
-                                      >
-                                        <EbiSpeciesIcon
-                                          groupColors={
-                                            Object {
-                                              "other": "deepskyblue",
-                                              "plants": "mediumseagreen",
-                                              "warmBlooded": "indianred",
-                                            }
-                                          }
-                                          species="drosophila melanogaster"
-                                        >
-                                          <span
-                                            className="icon icon-species"
-                                            data-icon="F"
-                                            style={
-                                              Object {
-                                                "color": "deepskyblue",
-                                              }
-                                            }
-                                            title="Drosophila melanogaster"
-                                          />
-                                        </EbiSpeciesIcon>
-                                      </span>
-                                    </a>
-                                    <h5>
-                                      <a
-                                        href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster"
-                                      >
-                                        Drosophila melanogaster
-                                      </a>
-                                    </h5>
-                                    <ul
-                                      style={
-                                        Object {
-                                          "listStyle": "none",
-                                          "marginLeft": 0,
-                                        }
-                                      }
-                                    >
-                                      <li
-                                        key="1 experiment-0"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        1 experiment
-                                      </li>
-                                      <li
-                                        key="Differential: 1-1"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        <a
-                                          href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster&experimentType=differential"
-                                        >
-                                          Differential: 1
-                                        </a>
-                                      </li>
-                                    </ul>
-                                  </div>
-                                </Card>
-                              </div>
-                            </StyledComponent>
-                          </styled.div>
-                        </div>
-                      </div>
-                      <div
-                        aria-hidden={false}
-                        className="slick-slide slick-active"
-                        data-index={4}
-                        key="original4"
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "outline": "none",
-                            "width": 0,
-                          }
-                        }
-                        tabIndex="-1"
-                      >
-                        <div
-                          key="44"
-                        >
-                          <styled.div
-                            className=""
-                            key="444"
-                            style={
-                              Object {
-                                "display": "inline-block",
-                                "width": "100%",
-                              }
-                            }
-                            tabIndex={-1}
-                          >
-                            <StyledComponent
-                              className=""
-                              forwardedComponent={
-                                Object {
-                                  "$$typeof": Symbol(react.forward_ref),
-                                  "attrs": Array [],
-                                  "componentStyle": ComponentStyle {
-                                    "componentId": "sc-bxivhb",
-                                    "isStatic": true,
-                                    "lastClassName": "gxCHar",
-                                    "rules": Array [
-                                      "
-    :hover {
-      background: ",
-                                      "AliceBlue",
-                                      ";
-    }
-  ",
-                                    ],
-                                  },
-                                  "displayName": "styled.div",
-                                  "foldedComponentIds": Array [],
-                                  "render": [Function],
-                                  "styledComponentId": "sc-bxivhb",
-                                  "target": "div",
-                                  "toString": [Function],
-                                  "warnTooManyClasses": [Function],
-                                  "withComponent": [Function],
-                                }
-                              }
-                              forwardedRef={null}
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "width": "100%",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <div
-                                className="sc-bxivhb gxCHar"
-                                style={
-                                  Object {
-                                    "display": "inline-block",
-                                    "width": "100%",
-                                  }
-                                }
-                                tabIndex={-1}
-                              >
-                                <Card
-                                  content={
-                                    Array [
-                                      Object {
-                                        "text": "1 experiment",
-                                      },
-                                      Object {
-                                        "text": "Differential: 1",
-                                        "url": "http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos&experimentType=differential",
-                                      },
-                                    ]
-                                  }
-                                  description={
-                                    Object {
-                                      "text": "Anas platyrhynchos",
-                                      "url": "http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos",
-                                    }
-                                  }
-                                  iconSrc="anas platyrhynchos"
-                                  iconType="species"
-                                  imageIconHeight="2rem"
-                                  speciesIconHeight="6rem"
-                                >
-                                  <div
-                                    style={
-                                      Object {
-                                        "marginBottom": 0,
-                                        "paddingBottom": "2rem",
-                                        "textAlign": "center",
-                                      }
-                                    }
-                                  >
-                                    <a
-                                      href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos"
-                                      style={
-                                        Object {
-                                          "borderBottom": 0,
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        style={
-                                          Object {
-                                            "fontSize": "6rem",
-                                          }
-                                        }
-                                      >
-                                        <EbiSpeciesIcon
-                                          groupColors={
-                                            Object {
-                                              "other": "deepskyblue",
-                                              "plants": "mediumseagreen",
-                                              "warmBlooded": "indianred",
-                                            }
-                                          }
-                                          species="anas platyrhynchos"
-                                        >
-                                          <span
-                                            className="icon icon-species"
-                                            data-icon="❔"
-                                            style={
-                                              Object {
-                                                "color": "black",
-                                              }
-                                            }
-                                            title="Anas platyrhynchos"
-                                          />
-                                        </EbiSpeciesIcon>
-                                      </span>
-                                    </a>
-                                    <h5>
-                                      <a
-                                        href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos"
-                                      >
-                                        Anas platyrhynchos
-                                      </a>
-                                    </h5>
-                                    <ul
-                                      style={
-                                        Object {
-                                          "listStyle": "none",
-                                          "marginLeft": 0,
-                                        }
-                                      }
-                                    >
-                                      <li
-                                        key="1 experiment-0"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        1 experiment
-                                      </li>
-                                      <li
-                                        key="Differential: 1-1"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        <a
-                                          href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos&experimentType=differential"
-                                        >
-                                          Differential: 1
-                                        </a>
-                                      </li>
-                                    </ul>
-                                  </div>
-                                </Card>
-                              </div>
-                            </StyledComponent>
-                          </styled.div>
-                        </div>
-                      </div>
-                      <div
-                        aria-hidden={false}
-                        className="slick-slide slick-active"
-                        data-index={5}
-                        key="original5"
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "outline": "none",
-                            "width": 0,
-                          }
-                        }
-                        tabIndex="-1"
-                      >
-                        <div
-                          key="55"
-                        >
-                          <styled.div
-                            className=""
-                            key="555"
-                            style={
-                              Object {
-                                "display": "inline-block",
-                                "width": "100%",
-                              }
-                            }
-                            tabIndex={-1}
-                          >
-                            <StyledComponent
-                              className=""
-                              forwardedComponent={
-                                Object {
-                                  "$$typeof": Symbol(react.forward_ref),
-                                  "attrs": Array [],
-                                  "componentStyle": ComponentStyle {
-                                    "componentId": "sc-bxivhb",
-                                    "isStatic": true,
-                                    "lastClassName": "gxCHar",
-                                    "rules": Array [
-                                      "
-    :hover {
-      background: ",
-                                      "AliceBlue",
-                                      ";
-    }
-  ",
-                                    ],
-                                  },
-                                  "displayName": "styled.div",
-                                  "foldedComponentIds": Array [],
-                                  "render": [Function],
-                                  "styledComponentId": "sc-bxivhb",
-                                  "target": "div",
-                                  "toString": [Function],
-                                  "warnTooManyClasses": [Function],
-                                  "withComponent": [Function],
-                                }
-                              }
-                              forwardedRef={null}
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "width": "100%",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <div
-                                className="sc-bxivhb gxCHar"
-                                style={
-                                  Object {
-                                    "display": "inline-block",
-                                    "width": "100%",
-                                  }
-                                }
-                                tabIndex={-1}
-                              >
-                                <Card
-                                  content={
-                                    Array [
-                                      Object {
-                                        "text": "1 experiment",
-                                      },
-                                      Object {
-                                        "text": "Differential: 1",
-                                        "url": "http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans&experimentType=differential",
-                                      },
-                                    ]
-                                  }
-                                  description={
-                                    Object {
-                                      "text": "Caenorhabditis elegans",
-                                      "url": "http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans",
-                                    }
-                                  }
-                                  iconSrc="caenorhabditis elegans"
-                                  iconType="species"
-                                  imageIconHeight="2rem"
-                                  speciesIconHeight="6rem"
-                                >
-                                  <div
-                                    style={
-                                      Object {
-                                        "marginBottom": 0,
-                                        "paddingBottom": "2rem",
-                                        "textAlign": "center",
-                                      }
-                                    }
-                                  >
-                                    <a
-                                      href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans"
-                                      style={
-                                        Object {
-                                          "borderBottom": 0,
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        style={
-                                          Object {
-                                            "fontSize": "6rem",
-                                          }
-                                        }
-                                      >
-                                        <EbiSpeciesIcon
-                                          groupColors={
-                                            Object {
-                                              "other": "deepskyblue",
-                                              "plants": "mediumseagreen",
-                                              "warmBlooded": "indianred",
-                                            }
-                                          }
-                                          species="caenorhabditis elegans"
-                                        >
-                                          <span
-                                            className="icon icon-species"
-                                            data-icon="W"
-                                            style={
-                                              Object {
-                                                "color": "deepskyblue",
-                                              }
-                                            }
-                                            title="Caenorhabditis elegans"
-                                          />
-                                        </EbiSpeciesIcon>
-                                      </span>
-                                    </a>
-                                    <h5>
-                                      <a
-                                        href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans"
-                                      >
-                                        Caenorhabditis elegans
-                                      </a>
-                                    </h5>
-                                    <ul
-                                      style={
-                                        Object {
-                                          "listStyle": "none",
-                                          "marginLeft": 0,
-                                        }
-                                      }
-                                    >
-                                      <li
-                                        key="1 experiment-0"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        1 experiment
-                                      </li>
-                                      <li
-                                        key="Differential: 1-1"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        <a
-                                          href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans&experimentType=differential"
-                                        >
-                                          Differential: 1
-                                        </a>
-                                      </li>
-                                    </ul>
-                                  </div>
-                                </Card>
-                              </div>
-                            </StyledComponent>
-                          </styled.div>
-                        </div>
-                      </div>
-                    </div>
-                  </Track>
-                </div>
+                          Differential: 3
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </Card>
               </div>
-            </InnerSlider>
-          </Slider>
+            </StyledComponent>
+          </styled.div>
+          <styled.div
+            className=""
+            key="1"
+          >
+            <StyledComponent
+              className=""
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-bxivhb",
+                    "isStatic": true,
+                    "lastClassName": "gxCHar",
+                    "rules": Array [
+                      "
+    :hover {
+      background: ",
+                      "AliceBlue",
+                      ";
+    }
+  ",
+                    ],
+                  },
+                  "displayName": "styled.div",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "sc-bxivhb",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="sc-bxivhb gxCHar"
+              >
+                <Card
+                  content={
+                    Array [
+                      Object {
+                        "text": "2 experiments",
+                      },
+                      Object {
+                        "text": "Differential: 2",
+                        "url": "http://localhost:8080/gxa/experiments?species=mus%20musculus&experimentType=differential",
+                      },
+                    ]
+                  }
+                  description={
+                    Object {
+                      "text": "Mus musculus",
+                      "url": "http://localhost:8080/gxa/experiments?species=mus%20musculus",
+                    }
+                  }
+                  iconSrc="mus musculus"
+                  iconType="species"
+                  imageIconHeight="2rem"
+                  speciesIconHeight="6rem"
+                >
+                  <div
+                    style={
+                      Object {
+                        "marginBottom": 0,
+                        "paddingBottom": "2rem",
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    <a
+                      href="http://localhost:8080/gxa/experiments?species=mus%20musculus"
+                      style={
+                        Object {
+                          "borderBottom": 0,
+                        }
+                      }
+                    >
+                      <span
+                        style={
+                          Object {
+                            "fontSize": "6rem",
+                          }
+                        }
+                      >
+                        <EbiSpeciesIcon
+                          groupColors={
+                            Object {
+                              "other": "deepskyblue",
+                              "plants": "mediumseagreen",
+                              "warmBlooded": "indianred",
+                            }
+                          }
+                          species="mus musculus"
+                        >
+                          <span
+                            className="icon icon-species"
+                            data-icon="M"
+                            style={
+                              Object {
+                                "color": "indianred",
+                              }
+                            }
+                            title="Mus musculus"
+                          />
+                        </EbiSpeciesIcon>
+                      </span>
+                    </a>
+                    <h5>
+                      <a
+                        href="http://localhost:8080/gxa/experiments?species=mus%20musculus"
+                      >
+                        Mus musculus
+                      </a>
+                    </h5>
+                    <ul
+                      style={
+                        Object {
+                          "listStyle": "none",
+                          "marginLeft": 0,
+                        }
+                      }
+                    >
+                      <li
+                        key="2 experiments-0"
+                        style={
+                          Object {
+                            "marginBottom": "0.3rem",
+                          }
+                        }
+                      >
+                        2 experiments
+                      </li>
+                      <li
+                        key="Differential: 2-1"
+                        style={
+                          Object {
+                            "marginBottom": "0.3rem",
+                          }
+                        }
+                      >
+                        <a
+                          href="http://localhost:8080/gxa/experiments?species=mus%20musculus&experimentType=differential"
+                        >
+                          Differential: 2
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </Card>
+              </div>
+            </StyledComponent>
+          </styled.div>
+          <styled.div
+            className=""
+            key="2"
+          >
+            <StyledComponent
+              className=""
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-bxivhb",
+                    "isStatic": true,
+                    "lastClassName": "gxCHar",
+                    "rules": Array [
+                      "
+    :hover {
+      background: ",
+                      "AliceBlue",
+                      ";
+    }
+  ",
+                    ],
+                  },
+                  "displayName": "styled.div",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "sc-bxivhb",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="sc-bxivhb gxCHar"
+              >
+                <Card
+                  content={
+                    Array [
+                      Object {
+                        "text": "1 experiment",
+                      },
+                      Object {
+                        "text": "Baseline: 1",
+                        "url": "http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni&experimentType=baseline",
+                      },
+                    ]
+                  }
+                  description={
+                    Object {
+                      "text": "Schistosoma mansoni",
+                      "url": "http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni",
+                    }
+                  }
+                  iconSrc="schistosoma mansoni"
+                  iconType="species"
+                  imageIconHeight="2rem"
+                  speciesIconHeight="6rem"
+                >
+                  <div
+                    style={
+                      Object {
+                        "marginBottom": 0,
+                        "paddingBottom": "2rem",
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    <a
+                      href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni"
+                      style={
+                        Object {
+                          "borderBottom": 0,
+                        }
+                      }
+                    >
+                      <span
+                        style={
+                          Object {
+                            "fontSize": "6rem",
+                          }
+                        }
+                      >
+                        <EbiSpeciesIcon
+                          groupColors={
+                            Object {
+                              "other": "deepskyblue",
+                              "plants": "mediumseagreen",
+                              "warmBlooded": "indianred",
+                            }
+                          }
+                          species="schistosoma mansoni"
+                        >
+                          <span
+                            className="icon icon-species"
+                            data-icon="W"
+                            style={
+                              Object {
+                                "color": "deepskyblue",
+                              }
+                            }
+                            title="Schistosoma mansoni"
+                          />
+                        </EbiSpeciesIcon>
+                      </span>
+                    </a>
+                    <h5>
+                      <a
+                        href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni"
+                      >
+                        Schistosoma mansoni
+                      </a>
+                    </h5>
+                    <ul
+                      style={
+                        Object {
+                          "listStyle": "none",
+                          "marginLeft": 0,
+                        }
+                      }
+                    >
+                      <li
+                        key="1 experiment-0"
+                        style={
+                          Object {
+                            "marginBottom": "0.3rem",
+                          }
+                        }
+                      >
+                        1 experiment
+                      </li>
+                      <li
+                        key="Baseline: 1-1"
+                        style={
+                          Object {
+                            "marginBottom": "0.3rem",
+                          }
+                        }
+                      >
+                        <a
+                          href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni&experimentType=baseline"
+                        >
+                          Baseline: 1
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </Card>
+              </div>
+            </StyledComponent>
+          </styled.div>
+          <styled.div
+            className=""
+            key="3"
+          >
+            <StyledComponent
+              className=""
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-bxivhb",
+                    "isStatic": true,
+                    "lastClassName": "gxCHar",
+                    "rules": Array [
+                      "
+    :hover {
+      background: ",
+                      "AliceBlue",
+                      ";
+    }
+  ",
+                    ],
+                  },
+                  "displayName": "styled.div",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "sc-bxivhb",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="sc-bxivhb gxCHar"
+              >
+                <Card
+                  content={
+                    Array [
+                      Object {
+                        "text": "1 experiment",
+                      },
+                      Object {
+                        "text": "Differential: 1",
+                        "url": "http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster&experimentType=differential",
+                      },
+                    ]
+                  }
+                  description={
+                    Object {
+                      "text": "Drosophila melanogaster",
+                      "url": "http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster",
+                    }
+                  }
+                  iconSrc="drosophila melanogaster"
+                  iconType="species"
+                  imageIconHeight="2rem"
+                  speciesIconHeight="6rem"
+                >
+                  <div
+                    style={
+                      Object {
+                        "marginBottom": 0,
+                        "paddingBottom": "2rem",
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    <a
+                      href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster"
+                      style={
+                        Object {
+                          "borderBottom": 0,
+                        }
+                      }
+                    >
+                      <span
+                        style={
+                          Object {
+                            "fontSize": "6rem",
+                          }
+                        }
+                      >
+                        <EbiSpeciesIcon
+                          groupColors={
+                            Object {
+                              "other": "deepskyblue",
+                              "plants": "mediumseagreen",
+                              "warmBlooded": "indianred",
+                            }
+                          }
+                          species="drosophila melanogaster"
+                        >
+                          <span
+                            className="icon icon-species"
+                            data-icon="F"
+                            style={
+                              Object {
+                                "color": "deepskyblue",
+                              }
+                            }
+                            title="Drosophila melanogaster"
+                          />
+                        </EbiSpeciesIcon>
+                      </span>
+                    </a>
+                    <h5>
+                      <a
+                        href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster"
+                      >
+                        Drosophila melanogaster
+                      </a>
+                    </h5>
+                    <ul
+                      style={
+                        Object {
+                          "listStyle": "none",
+                          "marginLeft": 0,
+                        }
+                      }
+                    >
+                      <li
+                        key="1 experiment-0"
+                        style={
+                          Object {
+                            "marginBottom": "0.3rem",
+                          }
+                        }
+                      >
+                        1 experiment
+                      </li>
+                      <li
+                        key="Differential: 1-1"
+                        style={
+                          Object {
+                            "marginBottom": "0.3rem",
+                          }
+                        }
+                      >
+                        <a
+                          href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster&experimentType=differential"
+                        >
+                          Differential: 1
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </Card>
+              </div>
+            </StyledComponent>
+          </styled.div>
+          <styled.div
+            className=""
+            key="4"
+          >
+            <StyledComponent
+              className=""
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-bxivhb",
+                    "isStatic": true,
+                    "lastClassName": "gxCHar",
+                    "rules": Array [
+                      "
+    :hover {
+      background: ",
+                      "AliceBlue",
+                      ";
+    }
+  ",
+                    ],
+                  },
+                  "displayName": "styled.div",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "sc-bxivhb",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="sc-bxivhb gxCHar"
+              >
+                <Card
+                  content={
+                    Array [
+                      Object {
+                        "text": "1 experiment",
+                      },
+                      Object {
+                        "text": "Differential: 1",
+                        "url": "http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos&experimentType=differential",
+                      },
+                    ]
+                  }
+                  description={
+                    Object {
+                      "text": "Anas platyrhynchos",
+                      "url": "http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos",
+                    }
+                  }
+                  iconSrc="anas platyrhynchos"
+                  iconType="species"
+                  imageIconHeight="2rem"
+                  speciesIconHeight="6rem"
+                >
+                  <div
+                    style={
+                      Object {
+                        "marginBottom": 0,
+                        "paddingBottom": "2rem",
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    <a
+                      href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos"
+                      style={
+                        Object {
+                          "borderBottom": 0,
+                        }
+                      }
+                    >
+                      <span
+                        style={
+                          Object {
+                            "fontSize": "6rem",
+                          }
+                        }
+                      >
+                        <EbiSpeciesIcon
+                          groupColors={
+                            Object {
+                              "other": "deepskyblue",
+                              "plants": "mediumseagreen",
+                              "warmBlooded": "indianred",
+                            }
+                          }
+                          species="anas platyrhynchos"
+                        >
+                          <span
+                            className="icon icon-species"
+                            data-icon="❔"
+                            style={
+                              Object {
+                                "color": "black",
+                              }
+                            }
+                            title="Anas platyrhynchos"
+                          />
+                        </EbiSpeciesIcon>
+                      </span>
+                    </a>
+                    <h5>
+                      <a
+                        href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos"
+                      >
+                        Anas platyrhynchos
+                      </a>
+                    </h5>
+                    <ul
+                      style={
+                        Object {
+                          "listStyle": "none",
+                          "marginLeft": 0,
+                        }
+                      }
+                    >
+                      <li
+                        key="1 experiment-0"
+                        style={
+                          Object {
+                            "marginBottom": "0.3rem",
+                          }
+                        }
+                      >
+                        1 experiment
+                      </li>
+                      <li
+                        key="Differential: 1-1"
+                        style={
+                          Object {
+                            "marginBottom": "0.3rem",
+                          }
+                        }
+                      >
+                        <a
+                          href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos&experimentType=differential"
+                        >
+                          Differential: 1
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </Card>
+              </div>
+            </StyledComponent>
+          </styled.div>
+          <styled.div
+            className=""
+            key="5"
+          >
+            <StyledComponent
+              className=""
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-bxivhb",
+                    "isStatic": true,
+                    "lastClassName": "gxCHar",
+                    "rules": Array [
+                      "
+    :hover {
+      background: ",
+                      "AliceBlue",
+                      ";
+    }
+  ",
+                    ],
+                  },
+                  "displayName": "styled.div",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "sc-bxivhb",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="sc-bxivhb gxCHar"
+              >
+                <Card
+                  content={
+                    Array [
+                      Object {
+                        "text": "1 experiment",
+                      },
+                      Object {
+                        "text": "Differential: 1",
+                        "url": "http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans&experimentType=differential",
+                      },
+                    ]
+                  }
+                  description={
+                    Object {
+                      "text": "Caenorhabditis elegans",
+                      "url": "http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans",
+                    }
+                  }
+                  iconSrc="caenorhabditis elegans"
+                  iconType="species"
+                  imageIconHeight="2rem"
+                  speciesIconHeight="6rem"
+                >
+                  <div
+                    style={
+                      Object {
+                        "marginBottom": 0,
+                        "paddingBottom": "2rem",
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    <a
+                      href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans"
+                      style={
+                        Object {
+                          "borderBottom": 0,
+                        }
+                      }
+                    >
+                      <span
+                        style={
+                          Object {
+                            "fontSize": "6rem",
+                          }
+                        }
+                      >
+                        <EbiSpeciesIcon
+                          groupColors={
+                            Object {
+                              "other": "deepskyblue",
+                              "plants": "mediumseagreen",
+                              "warmBlooded": "indianred",
+                            }
+                          }
+                          species="caenorhabditis elegans"
+                        >
+                          <span
+                            className="icon icon-species"
+                            data-icon="W"
+                            style={
+                              Object {
+                                "color": "deepskyblue",
+                              }
+                            }
+                            title="Caenorhabditis elegans"
+                          />
+                        </EbiSpeciesIcon>
+                      </span>
+                    </a>
+                    <h5>
+                      <a
+                        href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans"
+                      >
+                        Caenorhabditis elegans
+                      </a>
+                    </h5>
+                    <ul
+                      style={
+                        Object {
+                          "listStyle": "none",
+                          "marginLeft": 0,
+                        }
+                      }
+                    >
+                      <li
+                        key="1 experiment-0"
+                        style={
+                          Object {
+                            "marginBottom": "0.3rem",
+                          }
+                        }
+                      >
+                        1 experiment
+                      </li>
+                      <li
+                        key="Differential: 1-1"
+                        style={
+                          Object {
+                            "marginBottom": "0.3rem",
+                          }
+                        }
+                      >
+                        <a
+                          href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans&experimentType=differential"
+                        >
+                          Differential: 1
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </Card>
+              </div>
+            </StyledComponent>
+          </styled.div>
         </div>
       </CarouselCardsRow>
     </div>
@@ -1784,715 +1424,475 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
       >
         <div
           className=""
+          style={
+            Object {
+              "height": "350px",
+              "padding": "inherit",
+            }
+          }
         >
-          <GlobalStyleComponent />
-          <Slider
-            autoplay={true}
-            autoplaySpeed={2000}
-            dots={true}
-            infinite={true}
-            slidesToScroll={1}
-            slidesToShow={3}
-            speed={500}
+          <styled.div
+            className=""
+            key="0"
           >
-            <InnerSlider
-              accessibility={true}
-              adaptiveHeight={false}
-              afterChange={null}
-              appendDots={[Function]}
-              arrows={true}
-              autoplay={true}
-              autoplaySpeed={2000}
-              beforeChange={null}
-              centerMode={false}
-              centerPadding="50px"
+            <StyledComponent
               className=""
-              cssEase="ease"
-              customPaging={[Function]}
-              dots={true}
-              dotsClass="slick-dots"
-              draggable={true}
-              easing="linear"
-              edgeFriction={0.35}
-              fade={false}
-              focusOnSelect={false}
-              infinite={true}
-              initialSlide={0}
-              lazyLoad={null}
-              nextArrow={null}
-              onEdge={null}
-              onInit={null}
-              onLazyLoadError={null}
-              onReInit={null}
-              pauseOnDotsHover={false}
-              pauseOnFocus={false}
-              pauseOnHover={true}
-              prevArrow={null}
-              responsive={null}
-              rows={1}
-              rtl={false}
-              slide="div"
-              slidesPerRow={1}
-              slidesToScroll={1}
-              slidesToShow={3}
-              speed={500}
-              swipe={true}
-              swipeEvent={null}
-              swipeToSlide={false}
-              touchMove={true}
-              touchThreshold={5}
-              unslick={true}
-              useCSS={true}
-              useTransform={true}
-              variableWidth={false}
-              vertical={false}
-              waitForAnimate={true}
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-ifAKCX",
+                    "isStatic": true,
+                    "lastClassName": "gnXemY",
+                    "rules": Array [
+                      "
+    :hover {
+      background: ",
+                      "AliceBlue",
+                      ";
+    }
+  ",
+                    ],
+                  },
+                  "displayName": "styled.div",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "sc-ifAKCX",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
             >
               <div
-                className="slick-slider slick-initialized"
+                className="sc-ifAKCX gnXemY"
               >
-                <div
-                  className="slick-list"
-                >
-                  <Track
-                    centerMode={false}
-                    centerPadding="50px"
-                    cssEase="ease"
-                    currentSlide={0}
-                    fade={false}
-                    focusOnSelect={null}
-                    infinite={true}
-                    lazyLoad={null}
-                    lazyLoadedList={Array []}
-                    listHeight={0}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                    rtl={false}
-                    slideCount={3}
-                    slideHeight={0}
-                    slideWidth={0}
-                    slidesToScroll={1}
-                    slidesToShow={3}
-                    speed={500}
-                    trackStyle={
+                <Card
+                  content={
+                    Array [
                       Object {
-                        "WebkitTransform": "translate3d(0px, 0px, 0px)",
-                        "WebkitTransition": "",
-                        "msTransform": "translateX(0px)",
-                        "opacity": 1,
-                        "transform": "translate3d(0px, 0px, 0px)",
-                        "transition": "",
+                        "text": "3 experiments",
+                      },
+                      Object {
+                        "text": "Differential: 3",
+                        "url": "http://localhost:8080/gxa/experiments?species=oryza%20sativa&experimentType=differential",
+                      },
+                    ]
+                  }
+                  description={
+                    Object {
+                      "text": "Oryza sativa",
+                      "url": "http://localhost:8080/gxa/experiments?species=oryza%20sativa",
+                    }
+                  }
+                  iconSrc="oryza sativa"
+                  iconType="species"
+                  imageIconHeight="2rem"
+                  speciesIconHeight="6rem"
+                >
+                  <div
+                    style={
+                      Object {
+                        "marginBottom": 0,
+                        "paddingBottom": "2rem",
+                        "textAlign": "center",
                       }
                     }
-                    unslick={true}
-                    variableWidth={false}
-                    vertical={false}
                   >
-                    <div
-                      className="slick-track"
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseOver={[Function]}
+                    <a
+                      href="http://localhost:8080/gxa/experiments?species=oryza%20sativa"
                       style={
                         Object {
-                          "WebkitTransform": "translate3d(0px, 0px, 0px)",
-                          "WebkitTransition": "",
-                          "msTransform": "translateX(0px)",
-                          "opacity": 1,
-                          "transform": "translate3d(0px, 0px, 0px)",
-                          "transition": "",
+                          "borderBottom": 0,
                         }
                       }
                     >
-                      <div
-                        aria-hidden={false}
-                        className="slick-slide slick-active slick-current"
-                        data-index={0}
-                        key="original0"
-                        onClick={[Function]}
+                      <span
                         style={
                           Object {
-                            "outline": "none",
-                            "width": 0,
+                            "fontSize": "6rem",
                           }
                         }
-                        tabIndex="-1"
                       >
-                        <div
-                          key="0"
+                        <EbiSpeciesIcon
+                          groupColors={
+                            Object {
+                              "other": "deepskyblue",
+                              "plants": "mediumseagreen",
+                              "warmBlooded": "indianred",
+                            }
+                          }
+                          species="oryza sativa"
                         >
-                          <styled.div
-                            className=""
-                            key="0"
+                          <span
+                            className="icon icon-species"
+                            data-icon="6"
                             style={
                               Object {
-                                "display": "inline-block",
-                                "width": "100%",
+                                "color": "mediumseagreen",
                               }
                             }
-                            tabIndex={-1}
-                          >
-                            <StyledComponent
-                              className=""
-                              forwardedComponent={
-                                Object {
-                                  "$$typeof": Symbol(react.forward_ref),
-                                  "attrs": Array [],
-                                  "componentStyle": ComponentStyle {
-                                    "componentId": "sc-ifAKCX",
-                                    "isStatic": true,
-                                    "lastClassName": "gnXemY",
-                                    "rules": Array [
-                                      "
-    :hover {
-      background: ",
-                                      "AliceBlue",
-                                      ";
-    }
-  ",
-                                    ],
-                                  },
-                                  "displayName": "styled.div",
-                                  "foldedComponentIds": Array [],
-                                  "render": [Function],
-                                  "styledComponentId": "sc-ifAKCX",
-                                  "target": "div",
-                                  "toString": [Function],
-                                  "warnTooManyClasses": [Function],
-                                  "withComponent": [Function],
-                                }
-                              }
-                              forwardedRef={null}
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "width": "100%",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <div
-                                className="sc-ifAKCX gnXemY"
-                                style={
-                                  Object {
-                                    "display": "inline-block",
-                                    "width": "100%",
-                                  }
-                                }
-                                tabIndex={-1}
-                              >
-                                <Card
-                                  content={
-                                    Array [
-                                      Object {
-                                        "text": "3 experiments",
-                                      },
-                                      Object {
-                                        "text": "Differential: 3",
-                                        "url": "http://localhost:8080/gxa/experiments?species=oryza%20sativa&experimentType=differential",
-                                      },
-                                    ]
-                                  }
-                                  description={
-                                    Object {
-                                      "text": "Oryza sativa",
-                                      "url": "http://localhost:8080/gxa/experiments?species=oryza%20sativa",
-                                    }
-                                  }
-                                  iconSrc="oryza sativa"
-                                  iconType="species"
-                                  imageIconHeight="2rem"
-                                  speciesIconHeight="6rem"
-                                >
-                                  <div
-                                    style={
-                                      Object {
-                                        "marginBottom": 0,
-                                        "paddingBottom": "2rem",
-                                        "textAlign": "center",
-                                      }
-                                    }
-                                  >
-                                    <a
-                                      href="http://localhost:8080/gxa/experiments?species=oryza%20sativa"
-                                      style={
-                                        Object {
-                                          "borderBottom": 0,
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        style={
-                                          Object {
-                                            "fontSize": "6rem",
-                                          }
-                                        }
-                                      >
-                                        <EbiSpeciesIcon
-                                          groupColors={
-                                            Object {
-                                              "other": "deepskyblue",
-                                              "plants": "mediumseagreen",
-                                              "warmBlooded": "indianred",
-                                            }
-                                          }
-                                          species="oryza sativa"
-                                        >
-                                          <span
-                                            className="icon icon-species"
-                                            data-icon="6"
-                                            style={
-                                              Object {
-                                                "color": "mediumseagreen",
-                                              }
-                                            }
-                                            title="Oryza sativa"
-                                          />
-                                        </EbiSpeciesIcon>
-                                      </span>
-                                    </a>
-                                    <h5>
-                                      <a
-                                        href="http://localhost:8080/gxa/experiments?species=oryza%20sativa"
-                                      >
-                                        Oryza sativa
-                                      </a>
-                                    </h5>
-                                    <ul
-                                      style={
-                                        Object {
-                                          "listStyle": "none",
-                                          "marginLeft": 0,
-                                        }
-                                      }
-                                    >
-                                      <li
-                                        key="3 experiments-0"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        3 experiments
-                                      </li>
-                                      <li
-                                        key="Differential: 3-1"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        <a
-                                          href="http://localhost:8080/gxa/experiments?species=oryza%20sativa&experimentType=differential"
-                                        >
-                                          Differential: 3
-                                        </a>
-                                      </li>
-                                    </ul>
-                                  </div>
-                                </Card>
-                              </div>
-                            </StyledComponent>
-                          </styled.div>
-                        </div>
-                      </div>
-                      <div
-                        aria-hidden={false}
-                        className="slick-slide slick-active"
-                        data-index={1}
-                        key="original1"
-                        onClick={[Function]}
+                            title="Oryza sativa"
+                          />
+                        </EbiSpeciesIcon>
+                      </span>
+                    </a>
+                    <h5>
+                      <a
+                        href="http://localhost:8080/gxa/experiments?species=oryza%20sativa"
+                      >
+                        Oryza sativa
+                      </a>
+                    </h5>
+                    <ul
+                      style={
+                        Object {
+                          "listStyle": "none",
+                          "marginLeft": 0,
+                        }
+                      }
+                    >
+                      <li
+                        key="3 experiments-0"
                         style={
                           Object {
-                            "outline": "none",
-                            "width": 0,
+                            "marginBottom": "0.3rem",
                           }
                         }
-                        tabIndex="-1"
                       >
-                        <div
-                          key="11"
-                        >
-                          <styled.div
-                            className=""
-                            key="111"
-                            style={
-                              Object {
-                                "display": "inline-block",
-                                "width": "100%",
-                              }
-                            }
-                            tabIndex={-1}
-                          >
-                            <StyledComponent
-                              className=""
-                              forwardedComponent={
-                                Object {
-                                  "$$typeof": Symbol(react.forward_ref),
-                                  "attrs": Array [],
-                                  "componentStyle": ComponentStyle {
-                                    "componentId": "sc-ifAKCX",
-                                    "isStatic": true,
-                                    "lastClassName": "gnXemY",
-                                    "rules": Array [
-                                      "
-    :hover {
-      background: ",
-                                      "AliceBlue",
-                                      ";
-    }
-  ",
-                                    ],
-                                  },
-                                  "displayName": "styled.div",
-                                  "foldedComponentIds": Array [],
-                                  "render": [Function],
-                                  "styledComponentId": "sc-ifAKCX",
-                                  "target": "div",
-                                  "toString": [Function],
-                                  "warnTooManyClasses": [Function],
-                                  "withComponent": [Function],
-                                }
-                              }
-                              forwardedRef={null}
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "width": "100%",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <div
-                                className="sc-ifAKCX gnXemY"
-                                style={
-                                  Object {
-                                    "display": "inline-block",
-                                    "width": "100%",
-                                  }
-                                }
-                                tabIndex={-1}
-                              >
-                                <Card
-                                  content={
-                                    Array [
-                                      Object {
-                                        "text": "2 experiments",
-                                      },
-                                      Object {
-                                        "text": "Differential: 2",
-                                        "url": "http://localhost:8080/gxa/experiments?species=zea%20mays&experimentType=differential",
-                                      },
-                                    ]
-                                  }
-                                  description={
-                                    Object {
-                                      "text": "Zea mays",
-                                      "url": "http://localhost:8080/gxa/experiments?species=zea%20mays",
-                                    }
-                                  }
-                                  iconSrc="zea mays"
-                                  iconType="species"
-                                  imageIconHeight="2rem"
-                                  speciesIconHeight="6rem"
-                                >
-                                  <div
-                                    style={
-                                      Object {
-                                        "marginBottom": 0,
-                                        "paddingBottom": "2rem",
-                                        "textAlign": "center",
-                                      }
-                                    }
-                                  >
-                                    <a
-                                      href="http://localhost:8080/gxa/experiments?species=zea%20mays"
-                                      style={
-                                        Object {
-                                          "borderBottom": 0,
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        style={
-                                          Object {
-                                            "fontSize": "6rem",
-                                          }
-                                        }
-                                      >
-                                        <EbiSpeciesIcon
-                                          groupColors={
-                                            Object {
-                                              "other": "deepskyblue",
-                                              "plants": "mediumseagreen",
-                                              "warmBlooded": "indianred",
-                                            }
-                                          }
-                                          species="zea mays"
-                                        >
-                                          <span
-                                            className="icon icon-species"
-                                            data-icon="c"
-                                            style={
-                                              Object {
-                                                "color": "mediumseagreen",
-                                              }
-                                            }
-                                            title="Zea mays"
-                                          />
-                                        </EbiSpeciesIcon>
-                                      </span>
-                                    </a>
-                                    <h5>
-                                      <a
-                                        href="http://localhost:8080/gxa/experiments?species=zea%20mays"
-                                      >
-                                        Zea mays
-                                      </a>
-                                    </h5>
-                                    <ul
-                                      style={
-                                        Object {
-                                          "listStyle": "none",
-                                          "marginLeft": 0,
-                                        }
-                                      }
-                                    >
-                                      <li
-                                        key="2 experiments-0"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        2 experiments
-                                      </li>
-                                      <li
-                                        key="Differential: 2-1"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        <a
-                                          href="http://localhost:8080/gxa/experiments?species=zea%20mays&experimentType=differential"
-                                        >
-                                          Differential: 2
-                                        </a>
-                                      </li>
-                                    </ul>
-                                  </div>
-                                </Card>
-                              </div>
-                            </StyledComponent>
-                          </styled.div>
-                        </div>
-                      </div>
-                      <div
-                        aria-hidden={false}
-                        className="slick-slide slick-active"
-                        data-index={2}
-                        key="original2"
-                        onClick={[Function]}
+                        3 experiments
+                      </li>
+                      <li
+                        key="Differential: 3-1"
                         style={
                           Object {
-                            "outline": "none",
-                            "width": 0,
+                            "marginBottom": "0.3rem",
                           }
                         }
-                        tabIndex="-1"
                       >
-                        <div
-                          key="22"
+                        <a
+                          href="http://localhost:8080/gxa/experiments?species=oryza%20sativa&experimentType=differential"
                         >
-                          <styled.div
-                            className=""
-                            key="222"
-                            style={
-                              Object {
-                                "display": "inline-block",
-                                "width": "100%",
-                              }
-                            }
-                            tabIndex={-1}
-                          >
-                            <StyledComponent
-                              className=""
-                              forwardedComponent={
-                                Object {
-                                  "$$typeof": Symbol(react.forward_ref),
-                                  "attrs": Array [],
-                                  "componentStyle": ComponentStyle {
-                                    "componentId": "sc-ifAKCX",
-                                    "isStatic": true,
-                                    "lastClassName": "gnXemY",
-                                    "rules": Array [
-                                      "
-    :hover {
-      background: ",
-                                      "AliceBlue",
-                                      ";
-    }
-  ",
-                                    ],
-                                  },
-                                  "displayName": "styled.div",
-                                  "foldedComponentIds": Array [],
-                                  "render": [Function],
-                                  "styledComponentId": "sc-ifAKCX",
-                                  "target": "div",
-                                  "toString": [Function],
-                                  "warnTooManyClasses": [Function],
-                                  "withComponent": [Function],
-                                }
-                              }
-                              forwardedRef={null}
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "width": "100%",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <div
-                                className="sc-ifAKCX gnXemY"
-                                style={
-                                  Object {
-                                    "display": "inline-block",
-                                    "width": "100%",
-                                  }
-                                }
-                                tabIndex={-1}
-                              >
-                                <Card
-                                  content={
-                                    Array [
-                                      Object {
-                                        "text": "1 experiment",
-                                      },
-                                      Object {
-                                        "text": "Baseline: 1",
-                                        "url": "http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon&experimentType=baseline",
-                                      },
-                                    ]
-                                  }
-                                  description={
-                                    Object {
-                                      "text": "Brachypodium distachyon",
-                                      "url": "http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon",
-                                    }
-                                  }
-                                  iconSrc="brachypodium distachyon"
-                                  iconType="species"
-                                  imageIconHeight="2rem"
-                                  speciesIconHeight="6rem"
-                                >
-                                  <div
-                                    style={
-                                      Object {
-                                        "marginBottom": 0,
-                                        "paddingBottom": "2rem",
-                                        "textAlign": "center",
-                                      }
-                                    }
-                                  >
-                                    <a
-                                      href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon"
-                                      style={
-                                        Object {
-                                          "borderBottom": 0,
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        style={
-                                          Object {
-                                            "fontSize": "6rem",
-                                          }
-                                        }
-                                      >
-                                        <EbiSpeciesIcon
-                                          groupColors={
-                                            Object {
-                                              "other": "deepskyblue",
-                                              "plants": "mediumseagreen",
-                                              "warmBlooded": "indianred",
-                                            }
-                                          }
-                                          species="brachypodium distachyon"
-                                        >
-                                          <span
-                                            className="icon icon-species"
-                                            data-icon="%"
-                                            style={
-                                              Object {
-                                                "color": "mediumseagreen",
-                                              }
-                                            }
-                                            title="Brachypodium distachyon"
-                                          />
-                                        </EbiSpeciesIcon>
-                                      </span>
-                                    </a>
-                                    <h5>
-                                      <a
-                                        href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon"
-                                      >
-                                        Brachypodium distachyon
-                                      </a>
-                                    </h5>
-                                    <ul
-                                      style={
-                                        Object {
-                                          "listStyle": "none",
-                                          "marginLeft": 0,
-                                        }
-                                      }
-                                    >
-                                      <li
-                                        key="1 experiment-0"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        1 experiment
-                                      </li>
-                                      <li
-                                        key="Baseline: 1-1"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        <a
-                                          href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon&experimentType=baseline"
-                                        >
-                                          Baseline: 1
-                                        </a>
-                                      </li>
-                                    </ul>
-                                  </div>
-                                </Card>
-                              </div>
-                            </StyledComponent>
-                          </styled.div>
-                        </div>
-                      </div>
-                    </div>
-                  </Track>
-                </div>
+                          Differential: 3
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </Card>
               </div>
-            </InnerSlider>
-          </Slider>
+            </StyledComponent>
+          </styled.div>
+          <styled.div
+            className=""
+            key="1"
+          >
+            <StyledComponent
+              className=""
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-ifAKCX",
+                    "isStatic": true,
+                    "lastClassName": "gnXemY",
+                    "rules": Array [
+                      "
+    :hover {
+      background: ",
+                      "AliceBlue",
+                      ";
+    }
+  ",
+                    ],
+                  },
+                  "displayName": "styled.div",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "sc-ifAKCX",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="sc-ifAKCX gnXemY"
+              >
+                <Card
+                  content={
+                    Array [
+                      Object {
+                        "text": "2 experiments",
+                      },
+                      Object {
+                        "text": "Differential: 2",
+                        "url": "http://localhost:8080/gxa/experiments?species=zea%20mays&experimentType=differential",
+                      },
+                    ]
+                  }
+                  description={
+                    Object {
+                      "text": "Zea mays",
+                      "url": "http://localhost:8080/gxa/experiments?species=zea%20mays",
+                    }
+                  }
+                  iconSrc="zea mays"
+                  iconType="species"
+                  imageIconHeight="2rem"
+                  speciesIconHeight="6rem"
+                >
+                  <div
+                    style={
+                      Object {
+                        "marginBottom": 0,
+                        "paddingBottom": "2rem",
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    <a
+                      href="http://localhost:8080/gxa/experiments?species=zea%20mays"
+                      style={
+                        Object {
+                          "borderBottom": 0,
+                        }
+                      }
+                    >
+                      <span
+                        style={
+                          Object {
+                            "fontSize": "6rem",
+                          }
+                        }
+                      >
+                        <EbiSpeciesIcon
+                          groupColors={
+                            Object {
+                              "other": "deepskyblue",
+                              "plants": "mediumseagreen",
+                              "warmBlooded": "indianred",
+                            }
+                          }
+                          species="zea mays"
+                        >
+                          <span
+                            className="icon icon-species"
+                            data-icon="c"
+                            style={
+                              Object {
+                                "color": "mediumseagreen",
+                              }
+                            }
+                            title="Zea mays"
+                          />
+                        </EbiSpeciesIcon>
+                      </span>
+                    </a>
+                    <h5>
+                      <a
+                        href="http://localhost:8080/gxa/experiments?species=zea%20mays"
+                      >
+                        Zea mays
+                      </a>
+                    </h5>
+                    <ul
+                      style={
+                        Object {
+                          "listStyle": "none",
+                          "marginLeft": 0,
+                        }
+                      }
+                    >
+                      <li
+                        key="2 experiments-0"
+                        style={
+                          Object {
+                            "marginBottom": "0.3rem",
+                          }
+                        }
+                      >
+                        2 experiments
+                      </li>
+                      <li
+                        key="Differential: 2-1"
+                        style={
+                          Object {
+                            "marginBottom": "0.3rem",
+                          }
+                        }
+                      >
+                        <a
+                          href="http://localhost:8080/gxa/experiments?species=zea%20mays&experimentType=differential"
+                        >
+                          Differential: 2
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </Card>
+              </div>
+            </StyledComponent>
+          </styled.div>
+          <styled.div
+            className=""
+            key="2"
+          >
+            <StyledComponent
+              className=""
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-ifAKCX",
+                    "isStatic": true,
+                    "lastClassName": "gnXemY",
+                    "rules": Array [
+                      "
+    :hover {
+      background: ",
+                      "AliceBlue",
+                      ";
+    }
+  ",
+                    ],
+                  },
+                  "displayName": "styled.div",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "sc-ifAKCX",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="sc-ifAKCX gnXemY"
+              >
+                <Card
+                  content={
+                    Array [
+                      Object {
+                        "text": "1 experiment",
+                      },
+                      Object {
+                        "text": "Baseline: 1",
+                        "url": "http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon&experimentType=baseline",
+                      },
+                    ]
+                  }
+                  description={
+                    Object {
+                      "text": "Brachypodium distachyon",
+                      "url": "http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon",
+                    }
+                  }
+                  iconSrc="brachypodium distachyon"
+                  iconType="species"
+                  imageIconHeight="2rem"
+                  speciesIconHeight="6rem"
+                >
+                  <div
+                    style={
+                      Object {
+                        "marginBottom": 0,
+                        "paddingBottom": "2rem",
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    <a
+                      href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon"
+                      style={
+                        Object {
+                          "borderBottom": 0,
+                        }
+                      }
+                    >
+                      <span
+                        style={
+                          Object {
+                            "fontSize": "6rem",
+                          }
+                        }
+                      >
+                        <EbiSpeciesIcon
+                          groupColors={
+                            Object {
+                              "other": "deepskyblue",
+                              "plants": "mediumseagreen",
+                              "warmBlooded": "indianred",
+                            }
+                          }
+                          species="brachypodium distachyon"
+                        >
+                          <span
+                            className="icon icon-species"
+                            data-icon="%"
+                            style={
+                              Object {
+                                "color": "mediumseagreen",
+                              }
+                            }
+                            title="Brachypodium distachyon"
+                          />
+                        </EbiSpeciesIcon>
+                      </span>
+                    </a>
+                    <h5>
+                      <a
+                        href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon"
+                      >
+                        Brachypodium distachyon
+                      </a>
+                    </h5>
+                    <ul
+                      style={
+                        Object {
+                          "listStyle": "none",
+                          "marginLeft": 0,
+                        }
+                      }
+                    >
+                      <li
+                        key="1 experiment-0"
+                        style={
+                          Object {
+                            "marginBottom": "0.3rem",
+                          }
+                        }
+                      >
+                        1 experiment
+                      </li>
+                      <li
+                        key="Baseline: 1-1"
+                        style={
+                          Object {
+                            "marginBottom": "0.3rem",
+                          }
+                        }
+                      >
+                        <a
+                          href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon&experimentType=baseline"
+                        >
+                          Baseline: 1
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </Card>
+              </div>
+            </StyledComponent>
+          </styled.div>
         </div>
       </CarouselCardsRow>
     </div>
@@ -2543,327 +1943,167 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
       >
         <div
           className=""
+          style={
+            Object {
+              "height": "350px",
+              "padding": "inherit",
+            }
+          }
         >
-          <GlobalStyleComponent />
-          <Slider
-            autoplay={true}
-            autoplaySpeed={2000}
-            dots={true}
-            infinite={true}
-            slidesToScroll={1}
-            slidesToShow={1}
-            speed={500}
+          <styled.div
+            className=""
+            key="0"
           >
-            <InnerSlider
-              accessibility={true}
-              adaptiveHeight={false}
-              afterChange={null}
-              appendDots={[Function]}
-              arrows={true}
-              autoplay={true}
-              autoplaySpeed={2000}
-              beforeChange={null}
-              centerMode={false}
-              centerPadding="50px"
+            <StyledComponent
               className=""
-              cssEase="ease"
-              customPaging={[Function]}
-              dots={true}
-              dotsClass="slick-dots"
-              draggable={true}
-              easing="linear"
-              edgeFriction={0.35}
-              fade={false}
-              focusOnSelect={false}
-              infinite={true}
-              initialSlide={0}
-              lazyLoad={null}
-              nextArrow={null}
-              onEdge={null}
-              onInit={null}
-              onLazyLoadError={null}
-              onReInit={null}
-              pauseOnDotsHover={false}
-              pauseOnFocus={false}
-              pauseOnHover={true}
-              prevArrow={null}
-              responsive={null}
-              rows={1}
-              rtl={false}
-              slide="div"
-              slidesPerRow={1}
-              slidesToScroll={1}
-              slidesToShow={1}
-              speed={500}
-              swipe={true}
-              swipeEvent={null}
-              swipeToSlide={false}
-              touchMove={true}
-              touchThreshold={5}
-              unslick={true}
-              useCSS={true}
-              useTransform={true}
-              variableWidth={false}
-              vertical={false}
-              waitForAnimate={true}
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "sc-EHOje",
+                    "isStatic": true,
+                    "lastClassName": "fHEUvF",
+                    "rules": Array [
+                      "
+    :hover {
+      background: ",
+                      "AliceBlue",
+                      ";
+    }
+  ",
+                    ],
+                  },
+                  "displayName": "styled.div",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "sc-EHOje",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
             >
               <div
-                className="slick-slider slick-initialized"
+                className="sc-EHOje fHEUvF"
               >
-                <div
-                  className="slick-list"
-                >
-                  <Track
-                    centerMode={false}
-                    centerPadding="50px"
-                    cssEase="ease"
-                    currentSlide={0}
-                    fade={false}
-                    focusOnSelect={null}
-                    infinite={true}
-                    lazyLoad={null}
-                    lazyLoadedList={Array []}
-                    listHeight={0}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseOver={[Function]}
-                    rtl={false}
-                    slideCount={1}
-                    slideHeight={0}
-                    slideWidth={0}
-                    slidesToScroll={1}
-                    slidesToShow={1}
-                    speed={500}
-                    trackStyle={
+                <Card
+                  content={
+                    Array [
                       Object {
-                        "WebkitTransform": "translate3d(0px, 0px, 0px)",
-                        "WebkitTransition": "",
-                        "msTransform": "translateX(0px)",
-                        "opacity": 1,
-                        "transform": "translate3d(0px, 0px, 0px)",
-                        "transition": "",
+                        "text": "1 experiment",
+                      },
+                      Object {
+                        "text": "Differential: 1",
+                        "url": "http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae&experimentType=differential",
+                      },
+                    ]
+                  }
+                  description={
+                    Object {
+                      "text": "Saccharomyces cerevisiae",
+                      "url": "http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae",
+                    }
+                  }
+                  iconSrc="saccharomyces cerevisiae"
+                  iconType="species"
+                  imageIconHeight="2rem"
+                  speciesIconHeight="6rem"
+                >
+                  <div
+                    style={
+                      Object {
+                        "marginBottom": 0,
+                        "paddingBottom": "2rem",
+                        "textAlign": "center",
                       }
                     }
-                    unslick={true}
-                    variableWidth={false}
-                    vertical={false}
                   >
-                    <div
-                      className="slick-track"
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseOver={[Function]}
+                    <a
+                      href="http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae"
                       style={
                         Object {
-                          "WebkitTransform": "translate3d(0px, 0px, 0px)",
-                          "WebkitTransition": "",
-                          "msTransform": "translateX(0px)",
-                          "opacity": 1,
-                          "transform": "translate3d(0px, 0px, 0px)",
-                          "transition": "",
+                          "borderBottom": 0,
                         }
                       }
                     >
-                      <div
-                        aria-hidden={false}
-                        className="slick-slide slick-active slick-current"
-                        data-index={0}
-                        key="original0"
-                        onClick={[Function]}
+                      <span
                         style={
                           Object {
-                            "outline": "none",
-                            "width": 0,
+                            "fontSize": "6rem",
                           }
                         }
-                        tabIndex="-1"
                       >
-                        <div
-                          key="0"
+                        <EbiSpeciesIcon
+                          groupColors={
+                            Object {
+                              "other": "deepskyblue",
+                              "plants": "mediumseagreen",
+                              "warmBlooded": "indianred",
+                            }
+                          }
+                          species="saccharomyces cerevisiae"
                         >
-                          <styled.div
-                            className=""
-                            key="0"
+                          <span
+                            className="icon icon-species"
+                            data-icon="Y"
                             style={
                               Object {
-                                "display": "inline-block",
-                                "width": "100%",
+                                "color": "deepskyblue",
                               }
                             }
-                            tabIndex={-1}
-                          >
-                            <StyledComponent
-                              className=""
-                              forwardedComponent={
-                                Object {
-                                  "$$typeof": Symbol(react.forward_ref),
-                                  "attrs": Array [],
-                                  "componentStyle": ComponentStyle {
-                                    "componentId": "sc-EHOje",
-                                    "isStatic": true,
-                                    "lastClassName": "fHEUvF",
-                                    "rules": Array [
-                                      "
-    :hover {
-      background: ",
-                                      "AliceBlue",
-                                      ";
-    }
-  ",
-                                    ],
-                                  },
-                                  "displayName": "styled.div",
-                                  "foldedComponentIds": Array [],
-                                  "render": [Function],
-                                  "styledComponentId": "sc-EHOje",
-                                  "target": "div",
-                                  "toString": [Function],
-                                  "warnTooManyClasses": [Function],
-                                  "withComponent": [Function],
-                                }
-                              }
-                              forwardedRef={null}
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "width": "100%",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <div
-                                className="sc-EHOje fHEUvF"
-                                style={
-                                  Object {
-                                    "display": "inline-block",
-                                    "width": "100%",
-                                  }
-                                }
-                                tabIndex={-1}
-                              >
-                                <Card
-                                  content={
-                                    Array [
-                                      Object {
-                                        "text": "1 experiment",
-                                      },
-                                      Object {
-                                        "text": "Differential: 1",
-                                        "url": "http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae&experimentType=differential",
-                                      },
-                                    ]
-                                  }
-                                  description={
-                                    Object {
-                                      "text": "Saccharomyces cerevisiae",
-                                      "url": "http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae",
-                                    }
-                                  }
-                                  iconSrc="saccharomyces cerevisiae"
-                                  iconType="species"
-                                  imageIconHeight="2rem"
-                                  speciesIconHeight="6rem"
-                                >
-                                  <div
-                                    style={
-                                      Object {
-                                        "marginBottom": 0,
-                                        "paddingBottom": "2rem",
-                                        "textAlign": "center",
-                                      }
-                                    }
-                                  >
-                                    <a
-                                      href="http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae"
-                                      style={
-                                        Object {
-                                          "borderBottom": 0,
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        style={
-                                          Object {
-                                            "fontSize": "6rem",
-                                          }
-                                        }
-                                      >
-                                        <EbiSpeciesIcon
-                                          groupColors={
-                                            Object {
-                                              "other": "deepskyblue",
-                                              "plants": "mediumseagreen",
-                                              "warmBlooded": "indianred",
-                                            }
-                                          }
-                                          species="saccharomyces cerevisiae"
-                                        >
-                                          <span
-                                            className="icon icon-species"
-                                            data-icon="Y"
-                                            style={
-                                              Object {
-                                                "color": "deepskyblue",
-                                              }
-                                            }
-                                            title="Saccharomyces cerevisiae"
-                                          />
-                                        </EbiSpeciesIcon>
-                                      </span>
-                                    </a>
-                                    <h5>
-                                      <a
-                                        href="http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae"
-                                      >
-                                        Saccharomyces cerevisiae
-                                      </a>
-                                    </h5>
-                                    <ul
-                                      style={
-                                        Object {
-                                          "listStyle": "none",
-                                          "marginLeft": 0,
-                                        }
-                                      }
-                                    >
-                                      <li
-                                        key="1 experiment-0"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        1 experiment
-                                      </li>
-                                      <li
-                                        key="Differential: 1-1"
-                                        style={
-                                          Object {
-                                            "marginBottom": "0.3rem",
-                                          }
-                                        }
-                                      >
-                                        <a
-                                          href="http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae&experimentType=differential"
-                                        >
-                                          Differential: 1
-                                        </a>
-                                      </li>
-                                    </ul>
-                                  </div>
-                                </Card>
-                              </div>
-                            </StyledComponent>
-                          </styled.div>
-                        </div>
-                      </div>
-                    </div>
-                  </Track>
-                </div>
+                            title="Saccharomyces cerevisiae"
+                          />
+                        </EbiSpeciesIcon>
+                      </span>
+                    </a>
+                    <h5>
+                      <a
+                        href="http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae"
+                      >
+                        Saccharomyces cerevisiae
+                      </a>
+                    </h5>
+                    <ul
+                      style={
+                        Object {
+                          "listStyle": "none",
+                          "marginLeft": 0,
+                        }
+                      }
+                    >
+                      <li
+                        key="1 experiment-0"
+                        style={
+                          Object {
+                            "marginBottom": "0.3rem",
+                          }
+                        }
+                      >
+                        1 experiment
+                      </li>
+                      <li
+                        key="Differential: 1-1"
+                        style={
+                          Object {
+                            "marginBottom": "0.3rem",
+                          }
+                        }
+                      >
+                        <a
+                          href="http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae&experimentType=differential"
+                        >
+                          Differential: 1
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </Card>
               </div>
-            </InnerSlider>
-          </Slider>
+            </StyledComponent>
+          </styled.div>
         </div>
       </CarouselCardsRow>
     </div>

--- a/__test__/__snapshots__/SpeciesSummaryPanel.test.js.snap
+++ b/__test__/__snapshots__/SpeciesSummaryPanel.test.js.snap
@@ -2,6 +2,17 @@
 
 exports[`SpeciesSummaryPanel renders correctly 1`] = `
 <SpeciesSummaryPanel
+  carouselCardsRowProps={
+    Object {
+      "cardContainerClassName": "column",
+      "className": "row expanded small-up-2 medium-up-3 large-up-6",
+      "containerHeight": "320px",
+      "sliderHeight": "300px",
+      "sliderSettings": Object {
+        "slidesToShow": 1,
+      },
+    }
+  }
   onComponentDidMount={[Function]}
   responsiveCardsRowProps={Object {}}
   speciesSummary={
@@ -262,7 +273,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
     >
       <CarouselCardsRow
         CardClass={[Function]}
-        cardContainerClassName=""
+        cardContainerClassName="column"
         cards={
           Array [
             Object {
@@ -373,973 +384,2955 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
             },
           ]
         }
-        className=""
+        className="row expanded small-up-2 medium-up-3 large-up-6"
+        containerHeight="320px"
         hoverColour="AliceBlue"
         imageIconHeight="2rem"
-        slideSettings={
+        sliderHeight="300px"
+        sliderSettings={
           Object {
-            "autoplay": true,
-            "autoplaySpeed": 2000,
-            "dots": true,
-            "infinite": true,
-            "slidesToScroll": 1,
             "slidesToShow": 1,
-            "speed": 500,
           }
         }
         speciesIconHeight="6rem"
       >
         <div
-          className=""
+          className="row expanded small-up-2 medium-up-3 large-up-6"
           style={
             Object {
-              "height": "350px",
-              "padding": "inherit",
+              "height": "320px",
             }
           }
         >
-          <styled.div
-            className=""
-            key="0"
+          <GlobalStyleComponent
+            sliderHeight="300px"
+          />
+          <GlobalStyleComponent />
+          <Slider
+            slidesToShow={2}
           >
-            <StyledComponent
+            <InnerSlider
+              accessibility={true}
+              adaptiveHeight={false}
+              afterChange={null}
+              appendDots={[Function]}
+              arrows={true}
+              autoplay={false}
+              autoplaySpeed={3000}
+              beforeChange={null}
+              centerMode={false}
+              centerPadding="50px"
               className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-bxivhb",
-                    "isStatic": true,
-                    "lastClassName": "gxCHar",
-                    "rules": Array [
-                      "
-    :hover {
-      background: ",
-                      "AliceBlue",
-                      ";
-    }
-  ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-bxivhb",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
+              cssEase="ease"
+              customPaging={[Function]}
+              dots={false}
+              dotsClass="slick-dots"
+              draggable={true}
+              easing="linear"
+              edgeFriction={0.35}
+              fade={false}
+              focusOnSelect={false}
+              infinite={true}
+              initialSlide={0}
+              lazyLoad={null}
+              nextArrow={null}
+              onEdge={null}
+              onInit={null}
+              onLazyLoadError={null}
+              onReInit={null}
+              pauseOnDotsHover={false}
+              pauseOnFocus={false}
+              pauseOnHover={true}
+              prevArrow={null}
+              responsive={null}
+              rows={1}
+              rtl={false}
+              slide="div"
+              slidesPerRow={1}
+              slidesToScroll={1}
+              slidesToShow={2}
+              speed={500}
+              swipe={true}
+              swipeEvent={null}
+              swipeToSlide={false}
+              touchMove={true}
+              touchThreshold={5}
+              useCSS={true}
+              useTransform={true}
+              variableWidth={false}
+              vertical={false}
+              waitForAnimate={true}
             >
               <div
-                className="sc-bxivhb gxCHar"
+                className="slick-slider slick-initialized"
+                dir="ltr"
               >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "10 experiments",
-                      },
-                      Object {
-                        "text": "Baseline: 7",
-                        "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=baseline",
-                      },
-                      Object {
-                        "text": "Differential: 3",
-                        "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=differential",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Homo sapiens",
-                      "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens",
-                    }
-                  }
-                  iconSrc="homo sapiens"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
+                <PrevArrow
+                  centerMode={false}
+                  clickHandler={[Function]}
+                  currentSlide={0}
+                  infinite={true}
+                  nextArrow={null}
+                  prevArrow={null}
+                  slideCount={6}
+                  slidesToShow={2}
                 >
-                  <div
+                  <button
+                    className="slick-arrow slick-prev"
+                    data-role="none"
+                    key="0"
+                    onClick={[Function]}
                     style={
                       Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
+                        "display": "block",
                       }
                     }
+                    type="button"
                   >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=homo%20sapiens"
+                     
+                    Previous
+                  </button>
+                </PrevArrow>
+                <div
+                  className="slick-list"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={null}
+                  onMouseMove={null}
+                  onMouseUp={[Function]}
+                  onTouchCancel={null}
+                  onTouchEnd={[Function]}
+                  onTouchMove={null}
+                  onTouchStart={[Function]}
+                  style={Object {}}
+                >
+                  <Track
+                    centerMode={false}
+                    centerPadding="50px"
+                    cssEase="ease"
+                    currentSlide={0}
+                    fade={false}
+                    focusOnSelect={null}
+                    infinite={true}
+                    lazyLoad={null}
+                    lazyLoadedList={Array []}
+                    listHeight={0}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                    rtl={false}
+                    slideCount={6}
+                    slideHeight={0}
+                    slideWidth={0}
+                    slidesToScroll={1}
+                    slidesToShow={2}
+                    speed={500}
+                    trackStyle={
+                      Object {
+                        "WebkitTransform": "translate3d(0px, 0px, 0px)",
+                        "WebkitTransition": "",
+                        "msTransform": "translateX(0px)",
+                        "opacity": 1,
+                        "transform": "translate3d(0px, 0px, 0px)",
+                        "transition": "",
+                      }
+                    }
+                    variableWidth={false}
+                    vertical={false}
+                  >
+                    <div
+                      className="slick-track"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
                       style={
                         Object {
-                          "borderBottom": 0,
+                          "WebkitTransform": "translate3d(0px, 0px, 0px)",
+                          "WebkitTransition": "",
+                          "msTransform": "translateX(0px)",
+                          "opacity": 1,
+                          "transform": "translate3d(0px, 0px, 0px)",
+                          "transition": "",
                         }
                       }
                     >
-                      <span
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide slick-cloned"
+                        data-index={-2}
+                        key="precloned4"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "fontSize": "6rem",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="homo sapiens"
+                        <div
+                          key="44"
                         >
-                          <span
-                            className="icon icon-species"
-                            data-icon="H"
+                          <styled.div
+                            className="column"
+                            key="444"
                             style={
                               Object {
-                                "color": "indianred",
+                                "display": "inline-block",
+                                "width": "100%",
                               }
                             }
-                            title="Homo sapiens"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=homo%20sapiens"
-                      >
-                        Homo sapiens
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="10 experiments-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        10 experiments
-                      </li>
-                      <li
-                        key="Baseline: 7-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=baseline"
-                        >
-                          Baseline: 7
-                        </a>
-                      </li>
-                      <li
-                        key="Differential: 3-2"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=differential"
-                        >
-                          Differential: 3
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
-              </div>
-            </StyledComponent>
-          </styled.div>
-          <styled.div
-            className=""
-            key="1"
-          >
-            <StyledComponent
-              className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-bxivhb",
-                    "isStatic": true,
-                    "lastClassName": "gxCHar",
-                    "rules": Array [
-                      "
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bwzfXH",
+                                    "isStatic": true,
+                                    "lastClassName": "hgHOem",
+                                    "rules": Array [
+                                      "
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-bxivhb",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-bxivhb gxCHar"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "2 experiments",
-                      },
-                      Object {
-                        "text": "Differential: 2",
-                        "url": "http://localhost:8080/gxa/experiments?species=mus%20musculus&experimentType=differential",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Mus musculus",
-                      "url": "http://localhost:8080/gxa/experiments?species=mus%20musculus",
-                    }
-                  }
-                  iconSrc="mus musculus"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=mus%20musculus"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bwzfXH",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-bwzfXH hgHOem"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Differential: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Anas platyrhynchos",
+                                      "url": "http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos",
+                                    }
+                                  }
+                                  iconSrc="anas platyrhynchos"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="anas platyrhynchos"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="❔"
+                                            style={
+                                              Object {
+                                                "color": "black",
+                                              }
+                                            }
+                                            title="Anas platyrhynchos"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos"
+                                      >
+                                        Anas platyrhynchos
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Differential: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos&experimentType=differential"
+                                        >
+                                          Differential: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide slick-cloned"
+                        data-index={-1}
+                        key="precloned5"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "fontSize": "6rem",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="mus musculus"
+                        <div
+                          key="55"
                         >
-                          <span
-                            className="icon icon-species"
-                            data-icon="M"
+                          <styled.div
+                            className="column"
+                            key="555"
                             style={
                               Object {
-                                "color": "indianred",
+                                "display": "inline-block",
+                                "width": "100%",
                               }
                             }
-                            title="Mus musculus"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=mus%20musculus"
-                      >
-                        Mus musculus
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="2 experiments-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        2 experiments
-                      </li>
-                      <li
-                        key="Differential: 2-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=mus%20musculus&experimentType=differential"
-                        >
-                          Differential: 2
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
-              </div>
-            </StyledComponent>
-          </styled.div>
-          <styled.div
-            className=""
-            key="2"
-          >
-            <StyledComponent
-              className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-bxivhb",
-                    "isStatic": true,
-                    "lastClassName": "gxCHar",
-                    "rules": Array [
-                      "
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bwzfXH",
+                                    "isStatic": true,
+                                    "lastClassName": "hgHOem",
+                                    "rules": Array [
+                                      "
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-bxivhb",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-bxivhb gxCHar"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "1 experiment",
-                      },
-                      Object {
-                        "text": "Baseline: 1",
-                        "url": "http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni&experimentType=baseline",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Schistosoma mansoni",
-                      "url": "http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni",
-                    }
-                  }
-                  iconSrc="schistosoma mansoni"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bwzfXH",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-bwzfXH hgHOem"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Differential: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Caenorhabditis elegans",
+                                      "url": "http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans",
+                                    }
+                                  }
+                                  iconSrc="caenorhabditis elegans"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="caenorhabditis elegans"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="W"
+                                            style={
+                                              Object {
+                                                "color": "deepskyblue",
+                                              }
+                                            }
+                                            title="Caenorhabditis elegans"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans"
+                                      >
+                                        Caenorhabditis elegans
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Differential: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans&experimentType=differential"
+                                        >
+                                          Differential: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={false}
+                        className="slick-slide slick-active slick-current"
+                        data-index={0}
+                        key="original0"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "fontSize": "6rem",
+                            "outline": "none",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="schistosoma mansoni"
+                        <div
+                          key="0"
                         >
-                          <span
-                            className="icon icon-species"
-                            data-icon="W"
+                          <styled.div
+                            className="column"
+                            key="0"
                             style={
                               Object {
-                                "color": "deepskyblue",
+                                "display": "inline-block",
+                                "width": "100%",
                               }
                             }
-                            title="Schistosoma mansoni"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni"
-                      >
-                        Schistosoma mansoni
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="1 experiment-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        1 experiment
-                      </li>
-                      <li
-                        key="Baseline: 1-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni&experimentType=baseline"
-                        >
-                          Baseline: 1
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
-              </div>
-            </StyledComponent>
-          </styled.div>
-          <styled.div
-            className=""
-            key="3"
-          >
-            <StyledComponent
-              className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-bxivhb",
-                    "isStatic": true,
-                    "lastClassName": "gxCHar",
-                    "rules": Array [
-                      "
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bwzfXH",
+                                    "isStatic": true,
+                                    "lastClassName": "hgHOem",
+                                    "rules": Array [
+                                      "
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-bxivhb",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-bxivhb gxCHar"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "1 experiment",
-                      },
-                      Object {
-                        "text": "Differential: 1",
-                        "url": "http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster&experimentType=differential",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Drosophila melanogaster",
-                      "url": "http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster",
-                    }
-                  }
-                  iconSrc="drosophila melanogaster"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bwzfXH",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-bwzfXH hgHOem"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "10 experiments",
+                                      },
+                                      Object {
+                                        "text": "Baseline: 7",
+                                        "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=baseline",
+                                      },
+                                      Object {
+                                        "text": "Differential: 3",
+                                        "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Homo sapiens",
+                                      "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens",
+                                    }
+                                  }
+                                  iconSrc="homo sapiens"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=homo%20sapiens"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="homo sapiens"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="H"
+                                            style={
+                                              Object {
+                                                "color": "indianred",
+                                              }
+                                            }
+                                            title="Homo sapiens"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=homo%20sapiens"
+                                      >
+                                        Homo sapiens
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="10 experiments-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        10 experiments
+                                      </li>
+                                      <li
+                                        key="Baseline: 7-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=baseline"
+                                        >
+                                          Baseline: 7
+                                        </a>
+                                      </li>
+                                      <li
+                                        key="Differential: 3-2"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=differential"
+                                        >
+                                          Differential: 3
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={false}
+                        className="slick-slide slick-active"
+                        data-index={1}
+                        key="original1"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "fontSize": "6rem",
+                            "outline": "none",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="drosophila melanogaster"
+                        <div
+                          key="11"
                         >
-                          <span
-                            className="icon icon-species"
-                            data-icon="F"
+                          <styled.div
+                            className="column"
+                            key="111"
                             style={
                               Object {
-                                "color": "deepskyblue",
+                                "display": "inline-block",
+                                "width": "100%",
                               }
                             }
-                            title="Drosophila melanogaster"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster"
-                      >
-                        Drosophila melanogaster
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="1 experiment-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        1 experiment
-                      </li>
-                      <li
-                        key="Differential: 1-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster&experimentType=differential"
-                        >
-                          Differential: 1
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
-              </div>
-            </StyledComponent>
-          </styled.div>
-          <styled.div
-            className=""
-            key="4"
-          >
-            <StyledComponent
-              className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-bxivhb",
-                    "isStatic": true,
-                    "lastClassName": "gxCHar",
-                    "rules": Array [
-                      "
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bwzfXH",
+                                    "isStatic": true,
+                                    "lastClassName": "hgHOem",
+                                    "rules": Array [
+                                      "
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-bxivhb",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-bxivhb gxCHar"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "1 experiment",
-                      },
-                      Object {
-                        "text": "Differential: 1",
-                        "url": "http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos&experimentType=differential",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Anas platyrhynchos",
-                      "url": "http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos",
-                    }
-                  }
-                  iconSrc="anas platyrhynchos"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bwzfXH",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-bwzfXH hgHOem"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "2 experiments",
+                                      },
+                                      Object {
+                                        "text": "Differential: 2",
+                                        "url": "http://localhost:8080/gxa/experiments?species=mus%20musculus&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Mus musculus",
+                                      "url": "http://localhost:8080/gxa/experiments?species=mus%20musculus",
+                                    }
+                                  }
+                                  iconSrc="mus musculus"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=mus%20musculus"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="mus musculus"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="M"
+                                            style={
+                                              Object {
+                                                "color": "indianred",
+                                              }
+                                            }
+                                            title="Mus musculus"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=mus%20musculus"
+                                      >
+                                        Mus musculus
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="2 experiments-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        2 experiments
+                                      </li>
+                                      <li
+                                        key="Differential: 2-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=mus%20musculus&experimentType=differential"
+                                        >
+                                          Differential: 2
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide"
+                        data-index={2}
+                        key="original2"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "fontSize": "6rem",
+                            "outline": "none",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="anas platyrhynchos"
+                        <div
+                          key="22"
                         >
-                          <span
-                            className="icon icon-species"
-                            data-icon="❔"
+                          <styled.div
+                            className="column"
+                            key="222"
                             style={
                               Object {
-                                "color": "black",
+                                "display": "inline-block",
+                                "width": "100%",
                               }
                             }
-                            title="Anas platyrhynchos"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos"
-                      >
-                        Anas platyrhynchos
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="1 experiment-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        1 experiment
-                      </li>
-                      <li
-                        key="Differential: 1-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos&experimentType=differential"
-                        >
-                          Differential: 1
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
-              </div>
-            </StyledComponent>
-          </styled.div>
-          <styled.div
-            className=""
-            key="5"
-          >
-            <StyledComponent
-              className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-bxivhb",
-                    "isStatic": true,
-                    "lastClassName": "gxCHar",
-                    "rules": Array [
-                      "
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bwzfXH",
+                                    "isStatic": true,
+                                    "lastClassName": "hgHOem",
+                                    "rules": Array [
+                                      "
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-bxivhb",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-bxivhb gxCHar"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "1 experiment",
-                      },
-                      Object {
-                        "text": "Differential: 1",
-                        "url": "http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans&experimentType=differential",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Caenorhabditis elegans",
-                      "url": "http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans",
-                    }
-                  }
-                  iconSrc="caenorhabditis elegans"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bwzfXH",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-bwzfXH hgHOem"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Baseline: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni&experimentType=baseline",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Schistosoma mansoni",
+                                      "url": "http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni",
+                                    }
+                                  }
+                                  iconSrc="schistosoma mansoni"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="schistosoma mansoni"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="W"
+                                            style={
+                                              Object {
+                                                "color": "deepskyblue",
+                                              }
+                                            }
+                                            title="Schistosoma mansoni"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni"
+                                      >
+                                        Schistosoma mansoni
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Baseline: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni&experimentType=baseline"
+                                        >
+                                          Baseline: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide"
+                        data-index={3}
+                        key="original3"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "fontSize": "6rem",
+                            "outline": "none",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="caenorhabditis elegans"
+                        <div
+                          key="33"
                         >
-                          <span
-                            className="icon icon-species"
-                            data-icon="W"
+                          <styled.div
+                            className="column"
+                            key="333"
                             style={
                               Object {
-                                "color": "deepskyblue",
+                                "display": "inline-block",
+                                "width": "100%",
                               }
                             }
-                            title="Caenorhabditis elegans"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans"
-                      >
-                        Caenorhabditis elegans
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="1 experiment-0"
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bwzfXH",
+                                    "isStatic": true,
+                                    "lastClassName": "hgHOem",
+                                    "rules": Array [
+                                      "
+    :hover {
+      background: ",
+                                      "AliceBlue",
+                                      ";
+    }
+  ",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bwzfXH",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-bwzfXH hgHOem"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Differential: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Drosophila melanogaster",
+                                      "url": "http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster",
+                                    }
+                                  }
+                                  iconSrc="drosophila melanogaster"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="drosophila melanogaster"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="F"
+                                            style={
+                                              Object {
+                                                "color": "deepskyblue",
+                                              }
+                                            }
+                                            title="Drosophila melanogaster"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster"
+                                      >
+                                        Drosophila melanogaster
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Differential: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster&experimentType=differential"
+                                        >
+                                          Differential: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide"
+                        data-index={4}
+                        key="original4"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "marginBottom": "0.3rem",
+                            "outline": "none",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        1 experiment
-                      </li>
-                      <li
-                        key="Differential: 1-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans&experimentType=differential"
+                        <div
+                          key="44"
                         >
-                          Differential: 1
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
+                          <styled.div
+                            className="column"
+                            key="444"
+                            style={
+                              Object {
+                                "display": "inline-block",
+                                "width": "100%",
+                              }
+                            }
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bwzfXH",
+                                    "isStatic": true,
+                                    "lastClassName": "hgHOem",
+                                    "rules": Array [
+                                      "
+    :hover {
+      background: ",
+                                      "AliceBlue",
+                                      ";
+    }
+  ",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bwzfXH",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-bwzfXH hgHOem"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Differential: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Anas platyrhynchos",
+                                      "url": "http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos",
+                                    }
+                                  }
+                                  iconSrc="anas platyrhynchos"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="anas platyrhynchos"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="❔"
+                                            style={
+                                              Object {
+                                                "color": "black",
+                                              }
+                                            }
+                                            title="Anas platyrhynchos"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos"
+                                      >
+                                        Anas platyrhynchos
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Differential: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos&experimentType=differential"
+                                        >
+                                          Differential: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide"
+                        data-index={5}
+                        key="original5"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "outline": "none",
+                            "width": 0,
+                          }
+                        }
+                        tabIndex="-1"
+                      >
+                        <div
+                          key="55"
+                        >
+                          <styled.div
+                            className="column"
+                            key="555"
+                            style={
+                              Object {
+                                "display": "inline-block",
+                                "width": "100%",
+                              }
+                            }
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bwzfXH",
+                                    "isStatic": true,
+                                    "lastClassName": "hgHOem",
+                                    "rules": Array [
+                                      "
+    :hover {
+      background: ",
+                                      "AliceBlue",
+                                      ";
+    }
+  ",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bwzfXH",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-bwzfXH hgHOem"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Differential: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Caenorhabditis elegans",
+                                      "url": "http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans",
+                                    }
+                                  }
+                                  iconSrc="caenorhabditis elegans"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="caenorhabditis elegans"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="W"
+                                            style={
+                                              Object {
+                                                "color": "deepskyblue",
+                                              }
+                                            }
+                                            title="Caenorhabditis elegans"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans"
+                                      >
+                                        Caenorhabditis elegans
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Differential: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans&experimentType=differential"
+                                        >
+                                          Differential: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide slick-cloned"
+                        data-index={6}
+                        key="postcloned0"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "width": 0,
+                          }
+                        }
+                        tabIndex="-1"
+                      >
+                        <div
+                          key="0"
+                        >
+                          <styled.div
+                            className="column"
+                            key="0"
+                            style={
+                              Object {
+                                "display": "inline-block",
+                                "width": "100%",
+                              }
+                            }
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bwzfXH",
+                                    "isStatic": true,
+                                    "lastClassName": "hgHOem",
+                                    "rules": Array [
+                                      "
+    :hover {
+      background: ",
+                                      "AliceBlue",
+                                      ";
+    }
+  ",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bwzfXH",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-bwzfXH hgHOem"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "10 experiments",
+                                      },
+                                      Object {
+                                        "text": "Baseline: 7",
+                                        "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=baseline",
+                                      },
+                                      Object {
+                                        "text": "Differential: 3",
+                                        "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Homo sapiens",
+                                      "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens",
+                                    }
+                                  }
+                                  iconSrc="homo sapiens"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=homo%20sapiens"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="homo sapiens"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="H"
+                                            style={
+                                              Object {
+                                                "color": "indianred",
+                                              }
+                                            }
+                                            title="Homo sapiens"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=homo%20sapiens"
+                                      >
+                                        Homo sapiens
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="10 experiments-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        10 experiments
+                                      </li>
+                                      <li
+                                        key="Baseline: 7-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=baseline"
+                                        >
+                                          Baseline: 7
+                                        </a>
+                                      </li>
+                                      <li
+                                        key="Differential: 3-2"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=differential"
+                                        >
+                                          Differential: 3
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide slick-cloned"
+                        data-index={7}
+                        key="postcloned1"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "width": 0,
+                          }
+                        }
+                        tabIndex="-1"
+                      >
+                        <div
+                          key="11"
+                        >
+                          <styled.div
+                            className="column"
+                            key="111"
+                            style={
+                              Object {
+                                "display": "inline-block",
+                                "width": "100%",
+                              }
+                            }
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bwzfXH",
+                                    "isStatic": true,
+                                    "lastClassName": "hgHOem",
+                                    "rules": Array [
+                                      "
+    :hover {
+      background: ",
+                                      "AliceBlue",
+                                      ";
+    }
+  ",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bwzfXH",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-bwzfXH hgHOem"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "2 experiments",
+                                      },
+                                      Object {
+                                        "text": "Differential: 2",
+                                        "url": "http://localhost:8080/gxa/experiments?species=mus%20musculus&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Mus musculus",
+                                      "url": "http://localhost:8080/gxa/experiments?species=mus%20musculus",
+                                    }
+                                  }
+                                  iconSrc="mus musculus"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=mus%20musculus"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="mus musculus"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="M"
+                                            style={
+                                              Object {
+                                                "color": "indianred",
+                                              }
+                                            }
+                                            title="Mus musculus"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=mus%20musculus"
+                                      >
+                                        Mus musculus
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="2 experiments-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        2 experiments
+                                      </li>
+                                      <li
+                                        key="Differential: 2-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=mus%20musculus&experimentType=differential"
+                                        >
+                                          Differential: 2
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide slick-cloned"
+                        data-index={8}
+                        key="postcloned2"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "width": 0,
+                          }
+                        }
+                        tabIndex="-1"
+                      >
+                        <div
+                          key="22"
+                        >
+                          <styled.div
+                            className="column"
+                            key="222"
+                            style={
+                              Object {
+                                "display": "inline-block",
+                                "width": "100%",
+                              }
+                            }
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bwzfXH",
+                                    "isStatic": true,
+                                    "lastClassName": "hgHOem",
+                                    "rules": Array [
+                                      "
+    :hover {
+      background: ",
+                                      "AliceBlue",
+                                      ";
+    }
+  ",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bwzfXH",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-bwzfXH hgHOem"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Baseline: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni&experimentType=baseline",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Schistosoma mansoni",
+                                      "url": "http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni",
+                                    }
+                                  }
+                                  iconSrc="schistosoma mansoni"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="schistosoma mansoni"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="W"
+                                            style={
+                                              Object {
+                                                "color": "deepskyblue",
+                                              }
+                                            }
+                                            title="Schistosoma mansoni"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni"
+                                      >
+                                        Schistosoma mansoni
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Baseline: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni&experimentType=baseline"
+                                        >
+                                          Baseline: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide slick-cloned"
+                        data-index={9}
+                        key="postcloned3"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "width": 0,
+                          }
+                        }
+                        tabIndex="-1"
+                      >
+                        <div
+                          key="33"
+                        >
+                          <styled.div
+                            className="column"
+                            key="333"
+                            style={
+                              Object {
+                                "display": "inline-block",
+                                "width": "100%",
+                              }
+                            }
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bwzfXH",
+                                    "isStatic": true,
+                                    "lastClassName": "hgHOem",
+                                    "rules": Array [
+                                      "
+    :hover {
+      background: ",
+                                      "AliceBlue",
+                                      ";
+    }
+  ",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bwzfXH",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-bwzfXH hgHOem"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Differential: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Drosophila melanogaster",
+                                      "url": "http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster",
+                                    }
+                                  }
+                                  iconSrc="drosophila melanogaster"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="drosophila melanogaster"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="F"
+                                            style={
+                                              Object {
+                                                "color": "deepskyblue",
+                                              }
+                                            }
+                                            title="Drosophila melanogaster"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster"
+                                      >
+                                        Drosophila melanogaster
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Differential: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster&experimentType=differential"
+                                        >
+                                          Differential: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide slick-cloned"
+                        data-index={10}
+                        key="postcloned4"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "width": 0,
+                          }
+                        }
+                        tabIndex="-1"
+                      >
+                        <div
+                          key="44"
+                        >
+                          <styled.div
+                            className="column"
+                            key="444"
+                            style={
+                              Object {
+                                "display": "inline-block",
+                                "width": "100%",
+                              }
+                            }
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bwzfXH",
+                                    "isStatic": true,
+                                    "lastClassName": "hgHOem",
+                                    "rules": Array [
+                                      "
+    :hover {
+      background: ",
+                                      "AliceBlue",
+                                      ";
+    }
+  ",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bwzfXH",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-bwzfXH hgHOem"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Differential: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Anas platyrhynchos",
+                                      "url": "http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos",
+                                    }
+                                  }
+                                  iconSrc="anas platyrhynchos"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="anas platyrhynchos"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="❔"
+                                            style={
+                                              Object {
+                                                "color": "black",
+                                              }
+                                            }
+                                            title="Anas platyrhynchos"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos"
+                                      >
+                                        Anas platyrhynchos
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Differential: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos&experimentType=differential"
+                                        >
+                                          Differential: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide slick-cloned"
+                        data-index={11}
+                        key="postcloned5"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "width": 0,
+                          }
+                        }
+                        tabIndex="-1"
+                      >
+                        <div
+                          key="55"
+                        >
+                          <styled.div
+                            className="column"
+                            key="555"
+                            style={
+                              Object {
+                                "display": "inline-block",
+                                "width": "100%",
+                              }
+                            }
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bwzfXH",
+                                    "isStatic": true,
+                                    "lastClassName": "hgHOem",
+                                    "rules": Array [
+                                      "
+    :hover {
+      background: ",
+                                      "AliceBlue",
+                                      ";
+    }
+  ",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bwzfXH",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-bwzfXH hgHOem"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Differential: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Caenorhabditis elegans",
+                                      "url": "http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans",
+                                    }
+                                  }
+                                  iconSrc="caenorhabditis elegans"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="caenorhabditis elegans"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="W"
+                                            style={
+                                              Object {
+                                                "color": "deepskyblue",
+                                              }
+                                            }
+                                            title="Caenorhabditis elegans"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans"
+                                      >
+                                        Caenorhabditis elegans
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Differential: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans&experimentType=differential"
+                                        >
+                                          Differential: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                    </div>
+                  </Track>
+                </div>
+                <NextArrow
+                  centerMode={false}
+                  clickHandler={[Function]}
+                  currentSlide={0}
+                  infinite={true}
+                  nextArrow={null}
+                  prevArrow={null}
+                  slideCount={6}
+                  slidesToShow={2}
+                >
+                  <button
+                    className="slick-arrow slick-next"
+                    data-role="none"
+                    key="1"
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "display": "block",
+                      }
+                    }
+                    type="button"
+                  >
+                     
+                    Next
+                  </button>
+                </NextArrow>
               </div>
-            </StyledComponent>
-          </styled.div>
+            </InnerSlider>
+          </Slider>
         </div>
       </CarouselCardsRow>
     </div>
@@ -1350,7 +3343,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
     >
       <CarouselCardsRow
         CardClass={[Function]}
-        cardContainerClassName=""
+        cardContainerClassName="column"
         cards={
           Array [
             Object {
@@ -1406,493 +3399,1758 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
             },
           ]
         }
-        className=""
+        className="row expanded small-up-2 medium-up-3 large-up-6"
+        containerHeight="320px"
         hoverColour="AliceBlue"
         imageIconHeight="2rem"
-        slideSettings={
+        sliderHeight="300px"
+        sliderSettings={
           Object {
-            "autoplay": true,
-            "autoplaySpeed": 2000,
-            "dots": true,
-            "infinite": true,
-            "slidesToScroll": 1,
             "slidesToShow": 1,
-            "speed": 500,
           }
         }
         speciesIconHeight="6rem"
       >
         <div
-          className=""
+          className="row expanded small-up-2 medium-up-3 large-up-6"
           style={
             Object {
-              "height": "350px",
-              "padding": "inherit",
+              "height": "320px",
             }
           }
         >
-          <styled.div
-            className=""
-            key="0"
+          <GlobalStyleComponent
+            sliderHeight="300px"
+          />
+          <GlobalStyleComponent />
+          <Slider
+            slidesToShow={2}
           >
-            <StyledComponent
+            <InnerSlider
+              accessibility={true}
+              adaptiveHeight={false}
+              afterChange={null}
+              appendDots={[Function]}
+              arrows={true}
+              autoplay={false}
+              autoplaySpeed={3000}
+              beforeChange={null}
+              centerMode={false}
+              centerPadding="50px"
               className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-ifAKCX",
-                    "isStatic": true,
-                    "lastClassName": "gnXemY",
-                    "rules": Array [
-                      "
-    :hover {
-      background: ",
-                      "AliceBlue",
-                      ";
-    }
-  ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-ifAKCX",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
+              cssEase="ease"
+              customPaging={[Function]}
+              dots={false}
+              dotsClass="slick-dots"
+              draggable={true}
+              easing="linear"
+              edgeFriction={0.35}
+              fade={false}
+              focusOnSelect={false}
+              infinite={true}
+              initialSlide={0}
+              lazyLoad={null}
+              nextArrow={null}
+              onEdge={null}
+              onInit={null}
+              onLazyLoadError={null}
+              onReInit={null}
+              pauseOnDotsHover={false}
+              pauseOnFocus={false}
+              pauseOnHover={true}
+              prevArrow={null}
+              responsive={null}
+              rows={1}
+              rtl={false}
+              slide="div"
+              slidesPerRow={1}
+              slidesToScroll={1}
+              slidesToShow={2}
+              speed={500}
+              swipe={true}
+              swipeEvent={null}
+              swipeToSlide={false}
+              touchMove={true}
+              touchThreshold={5}
+              useCSS={true}
+              useTransform={true}
+              variableWidth={false}
+              vertical={false}
+              waitForAnimate={true}
             >
               <div
-                className="sc-ifAKCX gnXemY"
+                className="slick-slider slick-initialized"
+                dir="ltr"
               >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "3 experiments",
-                      },
-                      Object {
-                        "text": "Differential: 3",
-                        "url": "http://localhost:8080/gxa/experiments?species=oryza%20sativa&experimentType=differential",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Oryza sativa",
-                      "url": "http://localhost:8080/gxa/experiments?species=oryza%20sativa",
-                    }
-                  }
-                  iconSrc="oryza sativa"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
+                <PrevArrow
+                  centerMode={false}
+                  clickHandler={[Function]}
+                  currentSlide={0}
+                  infinite={true}
+                  nextArrow={null}
+                  prevArrow={null}
+                  slideCount={3}
+                  slidesToShow={2}
                 >
-                  <div
+                  <button
+                    className="slick-arrow slick-prev"
+                    data-role="none"
+                    key="0"
+                    onClick={[Function]}
                     style={
                       Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
+                        "display": "block",
                       }
                     }
+                    type="button"
                   >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=oryza%20sativa"
+                     
+                    Previous
+                  </button>
+                </PrevArrow>
+                <div
+                  className="slick-list"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={null}
+                  onMouseMove={null}
+                  onMouseUp={[Function]}
+                  onTouchCancel={null}
+                  onTouchEnd={[Function]}
+                  onTouchMove={null}
+                  onTouchStart={[Function]}
+                  style={Object {}}
+                >
+                  <Track
+                    centerMode={false}
+                    centerPadding="50px"
+                    cssEase="ease"
+                    currentSlide={0}
+                    fade={false}
+                    focusOnSelect={null}
+                    infinite={true}
+                    lazyLoad={null}
+                    lazyLoadedList={Array []}
+                    listHeight={0}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                    rtl={false}
+                    slideCount={3}
+                    slideHeight={0}
+                    slideWidth={0}
+                    slidesToScroll={1}
+                    slidesToShow={2}
+                    speed={500}
+                    trackStyle={
+                      Object {
+                        "WebkitTransform": "translate3d(0px, 0px, 0px)",
+                        "WebkitTransition": "",
+                        "msTransform": "translateX(0px)",
+                        "opacity": 1,
+                        "transform": "translate3d(0px, 0px, 0px)",
+                        "transition": "",
+                      }
+                    }
+                    variableWidth={false}
+                    vertical={false}
+                  >
+                    <div
+                      className="slick-track"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
                       style={
                         Object {
-                          "borderBottom": 0,
+                          "WebkitTransform": "translate3d(0px, 0px, 0px)",
+                          "WebkitTransition": "",
+                          "msTransform": "translateX(0px)",
+                          "opacity": 1,
+                          "transform": "translate3d(0px, 0px, 0px)",
+                          "transition": "",
                         }
                       }
                     >
-                      <span
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide slick-cloned"
+                        data-index={-2}
+                        key="precloned1"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "fontSize": "6rem",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="oryza sativa"
+                        <div
+                          key="11"
                         >
-                          <span
-                            className="icon icon-species"
-                            data-icon="6"
+                          <styled.div
+                            className="column"
+                            key="111"
                             style={
                               Object {
-                                "color": "mediumseagreen",
+                                "display": "inline-block",
+                                "width": "100%",
                               }
                             }
-                            title="Oryza sativa"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=oryza%20sativa"
-                      >
-                        Oryza sativa
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="3 experiments-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        3 experiments
-                      </li>
-                      <li
-                        key="Differential: 3-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=oryza%20sativa&experimentType=differential"
-                        >
-                          Differential: 3
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
-              </div>
-            </StyledComponent>
-          </styled.div>
-          <styled.div
-            className=""
-            key="1"
-          >
-            <StyledComponent
-              className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-ifAKCX",
-                    "isStatic": true,
-                    "lastClassName": "gnXemY",
-                    "rules": Array [
-                      "
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-htpNat",
+                                    "isStatic": true,
+                                    "lastClassName": "bhHEHk",
+                                    "rules": Array [
+                                      "
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-ifAKCX",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-ifAKCX gnXemY"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "2 experiments",
-                      },
-                      Object {
-                        "text": "Differential: 2",
-                        "url": "http://localhost:8080/gxa/experiments?species=zea%20mays&experimentType=differential",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Zea mays",
-                      "url": "http://localhost:8080/gxa/experiments?species=zea%20mays",
-                    }
-                  }
-                  iconSrc="zea mays"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=zea%20mays"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-htpNat",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-htpNat bhHEHk"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "2 experiments",
+                                      },
+                                      Object {
+                                        "text": "Differential: 2",
+                                        "url": "http://localhost:8080/gxa/experiments?species=zea%20mays&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Zea mays",
+                                      "url": "http://localhost:8080/gxa/experiments?species=zea%20mays",
+                                    }
+                                  }
+                                  iconSrc="zea mays"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=zea%20mays"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="zea mays"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="c"
+                                            style={
+                                              Object {
+                                                "color": "mediumseagreen",
+                                              }
+                                            }
+                                            title="Zea mays"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=zea%20mays"
+                                      >
+                                        Zea mays
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="2 experiments-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        2 experiments
+                                      </li>
+                                      <li
+                                        key="Differential: 2-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=zea%20mays&experimentType=differential"
+                                        >
+                                          Differential: 2
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide slick-cloned"
+                        data-index={-1}
+                        key="precloned2"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "fontSize": "6rem",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="zea mays"
+                        <div
+                          key="22"
                         >
-                          <span
-                            className="icon icon-species"
-                            data-icon="c"
+                          <styled.div
+                            className="column"
+                            key="222"
                             style={
                               Object {
-                                "color": "mediumseagreen",
+                                "display": "inline-block",
+                                "width": "100%",
                               }
                             }
-                            title="Zea mays"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=zea%20mays"
-                      >
-                        Zea mays
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="2 experiments-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        2 experiments
-                      </li>
-                      <li
-                        key="Differential: 2-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=zea%20mays&experimentType=differential"
-                        >
-                          Differential: 2
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
-              </div>
-            </StyledComponent>
-          </styled.div>
-          <styled.div
-            className=""
-            key="2"
-          >
-            <StyledComponent
-              className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-ifAKCX",
-                    "isStatic": true,
-                    "lastClassName": "gnXemY",
-                    "rules": Array [
-                      "
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-htpNat",
+                                    "isStatic": true,
+                                    "lastClassName": "bhHEHk",
+                                    "rules": Array [
+                                      "
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-ifAKCX",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-ifAKCX gnXemY"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "1 experiment",
-                      },
-                      Object {
-                        "text": "Baseline: 1",
-                        "url": "http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon&experimentType=baseline",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Brachypodium distachyon",
-                      "url": "http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon",
-                    }
-                  }
-                  iconSrc="brachypodium distachyon"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-htpNat",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-htpNat bhHEHk"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Baseline: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon&experimentType=baseline",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Brachypodium distachyon",
+                                      "url": "http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon",
+                                    }
+                                  }
+                                  iconSrc="brachypodium distachyon"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="brachypodium distachyon"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="%"
+                                            style={
+                                              Object {
+                                                "color": "mediumseagreen",
+                                              }
+                                            }
+                                            title="Brachypodium distachyon"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon"
+                                      >
+                                        Brachypodium distachyon
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Baseline: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon&experimentType=baseline"
+                                        >
+                                          Baseline: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={false}
+                        className="slick-slide slick-active slick-current"
+                        data-index={0}
+                        key="original0"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "fontSize": "6rem",
+                            "outline": "none",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="brachypodium distachyon"
+                        <div
+                          key="0"
                         >
-                          <span
-                            className="icon icon-species"
-                            data-icon="%"
+                          <styled.div
+                            className="column"
+                            key="0"
                             style={
                               Object {
-                                "color": "mediumseagreen",
+                                "display": "inline-block",
+                                "width": "100%",
                               }
                             }
-                            title="Brachypodium distachyon"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon"
-                      >
-                        Brachypodium distachyon
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="1 experiment-0"
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-htpNat",
+                                    "isStatic": true,
+                                    "lastClassName": "bhHEHk",
+                                    "rules": Array [
+                                      "
+    :hover {
+      background: ",
+                                      "AliceBlue",
+                                      ";
+    }
+  ",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-htpNat",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-htpNat bhHEHk"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "3 experiments",
+                                      },
+                                      Object {
+                                        "text": "Differential: 3",
+                                        "url": "http://localhost:8080/gxa/experiments?species=oryza%20sativa&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Oryza sativa",
+                                      "url": "http://localhost:8080/gxa/experiments?species=oryza%20sativa",
+                                    }
+                                  }
+                                  iconSrc="oryza sativa"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=oryza%20sativa"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="oryza sativa"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="6"
+                                            style={
+                                              Object {
+                                                "color": "mediumseagreen",
+                                              }
+                                            }
+                                            title="Oryza sativa"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=oryza%20sativa"
+                                      >
+                                        Oryza sativa
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="3 experiments-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        3 experiments
+                                      </li>
+                                      <li
+                                        key="Differential: 3-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=oryza%20sativa&experimentType=differential"
+                                        >
+                                          Differential: 3
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={false}
+                        className="slick-slide slick-active"
+                        data-index={1}
+                        key="original1"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "marginBottom": "0.3rem",
+                            "outline": "none",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        1 experiment
-                      </li>
-                      <li
-                        key="Baseline: 1-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon&experimentType=baseline"
+                        <div
+                          key="11"
                         >
-                          Baseline: 1
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
+                          <styled.div
+                            className="column"
+                            key="111"
+                            style={
+                              Object {
+                                "display": "inline-block",
+                                "width": "100%",
+                              }
+                            }
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-htpNat",
+                                    "isStatic": true,
+                                    "lastClassName": "bhHEHk",
+                                    "rules": Array [
+                                      "
+    :hover {
+      background: ",
+                                      "AliceBlue",
+                                      ";
+    }
+  ",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-htpNat",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-htpNat bhHEHk"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "2 experiments",
+                                      },
+                                      Object {
+                                        "text": "Differential: 2",
+                                        "url": "http://localhost:8080/gxa/experiments?species=zea%20mays&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Zea mays",
+                                      "url": "http://localhost:8080/gxa/experiments?species=zea%20mays",
+                                    }
+                                  }
+                                  iconSrc="zea mays"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=zea%20mays"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="zea mays"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="c"
+                                            style={
+                                              Object {
+                                                "color": "mediumseagreen",
+                                              }
+                                            }
+                                            title="Zea mays"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=zea%20mays"
+                                      >
+                                        Zea mays
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="2 experiments-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        2 experiments
+                                      </li>
+                                      <li
+                                        key="Differential: 2-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=zea%20mays&experimentType=differential"
+                                        >
+                                          Differential: 2
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide"
+                        data-index={2}
+                        key="original2"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "outline": "none",
+                            "width": 0,
+                          }
+                        }
+                        tabIndex="-1"
+                      >
+                        <div
+                          key="22"
+                        >
+                          <styled.div
+                            className="column"
+                            key="222"
+                            style={
+                              Object {
+                                "display": "inline-block",
+                                "width": "100%",
+                              }
+                            }
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-htpNat",
+                                    "isStatic": true,
+                                    "lastClassName": "bhHEHk",
+                                    "rules": Array [
+                                      "
+    :hover {
+      background: ",
+                                      "AliceBlue",
+                                      ";
+    }
+  ",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-htpNat",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-htpNat bhHEHk"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Baseline: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon&experimentType=baseline",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Brachypodium distachyon",
+                                      "url": "http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon",
+                                    }
+                                  }
+                                  iconSrc="brachypodium distachyon"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="brachypodium distachyon"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="%"
+                                            style={
+                                              Object {
+                                                "color": "mediumseagreen",
+                                              }
+                                            }
+                                            title="Brachypodium distachyon"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon"
+                                      >
+                                        Brachypodium distachyon
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Baseline: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon&experimentType=baseline"
+                                        >
+                                          Baseline: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide slick-cloned"
+                        data-index={3}
+                        key="postcloned0"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "width": 0,
+                          }
+                        }
+                        tabIndex="-1"
+                      >
+                        <div
+                          key="0"
+                        >
+                          <styled.div
+                            className="column"
+                            key="0"
+                            style={
+                              Object {
+                                "display": "inline-block",
+                                "width": "100%",
+                              }
+                            }
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-htpNat",
+                                    "isStatic": true,
+                                    "lastClassName": "bhHEHk",
+                                    "rules": Array [
+                                      "
+    :hover {
+      background: ",
+                                      "AliceBlue",
+                                      ";
+    }
+  ",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-htpNat",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-htpNat bhHEHk"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "3 experiments",
+                                      },
+                                      Object {
+                                        "text": "Differential: 3",
+                                        "url": "http://localhost:8080/gxa/experiments?species=oryza%20sativa&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Oryza sativa",
+                                      "url": "http://localhost:8080/gxa/experiments?species=oryza%20sativa",
+                                    }
+                                  }
+                                  iconSrc="oryza sativa"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=oryza%20sativa"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="oryza sativa"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="6"
+                                            style={
+                                              Object {
+                                                "color": "mediumseagreen",
+                                              }
+                                            }
+                                            title="Oryza sativa"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=oryza%20sativa"
+                                      >
+                                        Oryza sativa
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="3 experiments-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        3 experiments
+                                      </li>
+                                      <li
+                                        key="Differential: 3-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=oryza%20sativa&experimentType=differential"
+                                        >
+                                          Differential: 3
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide slick-cloned"
+                        data-index={4}
+                        key="postcloned1"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "width": 0,
+                          }
+                        }
+                        tabIndex="-1"
+                      >
+                        <div
+                          key="11"
+                        >
+                          <styled.div
+                            className="column"
+                            key="111"
+                            style={
+                              Object {
+                                "display": "inline-block",
+                                "width": "100%",
+                              }
+                            }
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-htpNat",
+                                    "isStatic": true,
+                                    "lastClassName": "bhHEHk",
+                                    "rules": Array [
+                                      "
+    :hover {
+      background: ",
+                                      "AliceBlue",
+                                      ";
+    }
+  ",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-htpNat",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-htpNat bhHEHk"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "2 experiments",
+                                      },
+                                      Object {
+                                        "text": "Differential: 2",
+                                        "url": "http://localhost:8080/gxa/experiments?species=zea%20mays&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Zea mays",
+                                      "url": "http://localhost:8080/gxa/experiments?species=zea%20mays",
+                                    }
+                                  }
+                                  iconSrc="zea mays"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=zea%20mays"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="zea mays"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="c"
+                                            style={
+                                              Object {
+                                                "color": "mediumseagreen",
+                                              }
+                                            }
+                                            title="Zea mays"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=zea%20mays"
+                                      >
+                                        Zea mays
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="2 experiments-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        2 experiments
+                                      </li>
+                                      <li
+                                        key="Differential: 2-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=zea%20mays&experimentType=differential"
+                                        >
+                                          Differential: 2
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={true}
+                        className="slick-slide slick-cloned"
+                        data-index={5}
+                        key="postcloned2"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "width": 0,
+                          }
+                        }
+                        tabIndex="-1"
+                      >
+                        <div
+                          key="22"
+                        >
+                          <styled.div
+                            className="column"
+                            key="222"
+                            style={
+                              Object {
+                                "display": "inline-block",
+                                "width": "100%",
+                              }
+                            }
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className="column"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-htpNat",
+                                    "isStatic": true,
+                                    "lastClassName": "bhHEHk",
+                                    "rules": Array [
+                                      "
+    :hover {
+      background: ",
+                                      "AliceBlue",
+                                      ";
+    }
+  ",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-htpNat",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="column sc-htpNat bhHEHk"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Baseline: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon&experimentType=baseline",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Brachypodium distachyon",
+                                      "url": "http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon",
+                                    }
+                                  }
+                                  iconSrc="brachypodium distachyon"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="brachypodium distachyon"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="%"
+                                            style={
+                                              Object {
+                                                "color": "mediumseagreen",
+                                              }
+                                            }
+                                            title="Brachypodium distachyon"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon"
+                                      >
+                                        Brachypodium distachyon
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Baseline: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon&experimentType=baseline"
+                                        >
+                                          Baseline: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                    </div>
+                  </Track>
+                </div>
+                <NextArrow
+                  centerMode={false}
+                  clickHandler={[Function]}
+                  currentSlide={0}
+                  infinite={true}
+                  nextArrow={null}
+                  prevArrow={null}
+                  slideCount={3}
+                  slidesToShow={2}
+                >
+                  <button
+                    className="slick-arrow slick-next"
+                    data-role="none"
+                    key="1"
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "display": "block",
+                      }
+                    }
+                    type="button"
+                  >
+                     
+                    Next
+                  </button>
+                </NextArrow>
               </div>
-            </StyledComponent>
-          </styled.div>
+            </InnerSlider>
+          </Slider>
         </div>
       </CarouselCardsRow>
     </div>
@@ -1903,7 +5161,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
     >
       <CarouselCardsRow
         CardClass={[Function]}
-        cardContainerClassName=""
+        cardContainerClassName="column"
         cards={
           Array [
             Object {
@@ -1925,45 +5183,40 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
             },
           ]
         }
-        className=""
+        className="row expanded small-up-2 medium-up-3 large-up-6"
+        containerHeight="320px"
         hoverColour="AliceBlue"
         imageIconHeight="2rem"
-        slideSettings={
+        sliderHeight="300px"
+        sliderSettings={
           Object {
-            "autoplay": true,
-            "autoplaySpeed": 2000,
-            "dots": true,
-            "infinite": true,
-            "slidesToScroll": 1,
             "slidesToShow": 1,
-            "speed": 500,
           }
         }
         speciesIconHeight="6rem"
       >
         <div
-          className=""
+          className="row expanded small-up-2 medium-up-3 large-up-6"
           style={
             Object {
-              "height": "350px",
-              "padding": "inherit",
+              "height": "320px",
             }
           }
         >
           <styled.div
-            className=""
+            className="column"
             key="0"
           >
             <StyledComponent
-              className=""
+              className="column"
               forwardedComponent={
                 Object {
                   "$$typeof": Symbol(react.forward_ref),
                   "attrs": Array [],
                   "componentStyle": ComponentStyle {
-                    "componentId": "sc-EHOje",
+                    "componentId": "sc-bxivhb",
                     "isStatic": true,
-                    "lastClassName": "fHEUvF",
+                    "lastClassName": "gxCHar",
                     "rules": Array [
                       "
     :hover {
@@ -1977,7 +5230,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                   "displayName": "styled.div",
                   "foldedComponentIds": Array [],
                   "render": [Function],
-                  "styledComponentId": "sc-EHOje",
+                  "styledComponentId": "sc-bxivhb",
                   "target": "div",
                   "toString": [Function],
                   "warnTooManyClasses": [Function],
@@ -1987,7 +5240,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
               forwardedRef={null}
             >
               <div
-                className="sc-EHOje fHEUvF"
+                className="column sc-bxivhb gxCHar"
               >
                 <Card
                   content={
@@ -2113,6 +5366,17 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
 
 exports[`SpeciesSummaryPanel renders correctly 2`] = `
 <SpeciesSummaryPanel
+  carouselCardsRowProps={
+    Object {
+      "cardContainerClassName": "column",
+      "className": "row expanded small-up-2 medium-up-3 large-up-6",
+      "containerHeight": "320px",
+      "sliderHeight": "300px",
+      "sliderSettings": Object {
+        "slidesToShow": 1,
+      },
+    }
+  }
   onComponentDidMount={[Function]}
   responsiveCardsRowProps={Object {}}
   speciesSummary={Array []}

--- a/__test__/__snapshots__/SpeciesSummaryPanel.test.js.snap
+++ b/__test__/__snapshots__/SpeciesSummaryPanel.test.js.snap
@@ -260,7 +260,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
       id="animals"
       key="0"
     >
-      <ResponsiveCardsRow
+      <CarousleCardsRow
         CardClass={[Function]}
         cardContainerClassName=""
         cards={
@@ -376,968 +376,1346 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
         className=""
         hoverColour="AliceBlue"
         imageIconHeight="2rem"
+        slideSettings={
+          Object {
+            "autoplay": true,
+            "autoplaySpeed": 2000,
+            "dots": true,
+            "infinite": true,
+            "slidesToScroll": 1,
+            "slidesToShow": 1,
+            "speed": 500,
+          }
+        }
         speciesIconHeight="6rem"
       >
         <div
           className=""
         >
-          <styled.div
-            className=""
-            key="0"
+          <Slider
+            autoplay={true}
+            autoplaySpeed={2000}
+            dots={true}
+            id="slide"
+            infinite={true}
+            slidesToScroll={1}
+            slidesToShow={6}
+            speed={500}
           >
-            <StyledComponent
+            <InnerSlider
+              accessibility={true}
+              adaptiveHeight={false}
+              afterChange={null}
+              appendDots={[Function]}
+              arrows={true}
+              autoplay={true}
+              autoplaySpeed={2000}
+              beforeChange={null}
+              centerMode={false}
+              centerPadding="50px"
               className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-bxivhb",
-                    "isStatic": true,
-                    "lastClassName": "hfBy",
-                    "rules": Array [
-                      "
+              cssEase="ease"
+              customPaging={[Function]}
+              dots={true}
+              dotsClass="slick-dots"
+              draggable={true}
+              easing="linear"
+              edgeFriction={0.35}
+              fade={false}
+              focusOnSelect={false}
+              id="slide"
+              infinite={true}
+              initialSlide={0}
+              lazyLoad={null}
+              nextArrow={null}
+              onEdge={null}
+              onInit={null}
+              onLazyLoadError={null}
+              onReInit={null}
+              pauseOnDotsHover={false}
+              pauseOnFocus={false}
+              pauseOnHover={true}
+              prevArrow={null}
+              responsive={null}
+              rows={1}
+              rtl={false}
+              slide="div"
+              slidesPerRow={1}
+              slidesToScroll={1}
+              slidesToShow={6}
+              speed={500}
+              swipe={true}
+              swipeEvent={null}
+              swipeToSlide={false}
+              touchMove={true}
+              touchThreshold={5}
+              unslick={true}
+              useCSS={true}
+              useTransform={true}
+              variableWidth={false}
+              vertical={false}
+              waitForAnimate={true}
+            >
+              <div
+                className="slick-slider slick-initialized"
+              >
+                <div
+                  className="slick-list"
+                >
+                  <Track
+                    centerMode={false}
+                    centerPadding="50px"
+                    cssEase="ease"
+                    currentSlide={0}
+                    fade={false}
+                    focusOnSelect={null}
+                    infinite={true}
+                    lazyLoad={null}
+                    lazyLoadedList={Array []}
+                    listHeight={0}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                    rtl={false}
+                    slideCount={6}
+                    slideHeight={0}
+                    slideWidth={0}
+                    slidesToScroll={1}
+                    slidesToShow={6}
+                    speed={500}
+                    trackStyle={
+                      Object {
+                        "WebkitTransform": "translate3d(0px, 0px, 0px)",
+                        "WebkitTransition": "",
+                        "msTransform": "translateX(0px)",
+                        "opacity": 1,
+                        "transform": "translate3d(0px, 0px, 0px)",
+                        "transition": "",
+                      }
+                    }
+                    unslick={true}
+                    variableWidth={false}
+                    vertical={false}
+                  >
+                    <div
+                      className="slick-track"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                      style={
+                        Object {
+                          "WebkitTransform": "translate3d(0px, 0px, 0px)",
+                          "WebkitTransition": "",
+                          "msTransform": "translateX(0px)",
+                          "opacity": 1,
+                          "transform": "translate3d(0px, 0px, 0px)",
+                          "transition": "",
+                        }
+                      }
+                    >
+                      <div
+                        aria-hidden={false}
+                        className="slick-slide slick-active slick-current"
+                        data-index={0}
+                        key="original0"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "outline": "none",
+                            "width": 0,
+                          }
+                        }
+                        tabIndex="-1"
+                      >
+                        <div
+                          key="0"
+                        >
+                          <styled.div
+                            className=""
+                            key="0"
+                            style={
+                              Object {
+                                "display": "inline-block",
+                                "width": "100%",
+                              }
+                            }
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className=""
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bxivhb",
+                                    "isStatic": true,
+                                    "lastClassName": "hfBy",
+                                    "rules": Array [
+                                      "
     /* border-radius: 8px; */
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-bxivhb",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-bxivhb hfBy"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "10 experiments",
-                      },
-                      Object {
-                        "text": "Baseline: 7",
-                        "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=baseline",
-                      },
-                      Object {
-                        "text": "Differential: 3",
-                        "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=differential",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Homo sapiens",
-                      "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens",
-                    }
-                  }
-                  iconSrc="homo sapiens"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=homo%20sapiens"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bxivhb",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="sc-bxivhb hfBy"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "10 experiments",
+                                      },
+                                      Object {
+                                        "text": "Baseline: 7",
+                                        "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=baseline",
+                                      },
+                                      Object {
+                                        "text": "Differential: 3",
+                                        "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Homo sapiens",
+                                      "url": "http://localhost:8080/gxa/experiments?species=homo%20sapiens",
+                                    }
+                                  }
+                                  iconSrc="homo sapiens"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=homo%20sapiens"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="homo sapiens"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="H"
+                                            style={
+                                              Object {
+                                                "color": "indianred",
+                                              }
+                                            }
+                                            title="Homo sapiens"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=homo%20sapiens"
+                                      >
+                                        Homo sapiens
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="10 experiments-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        10 experiments
+                                      </li>
+                                      <li
+                                        key="Baseline: 7-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=baseline"
+                                        >
+                                          Baseline: 7
+                                        </a>
+                                      </li>
+                                      <li
+                                        key="Differential: 3-2"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=differential"
+                                        >
+                                          Differential: 3
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={false}
+                        className="slick-slide slick-active"
+                        data-index={1}
+                        key="original1"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "fontSize": "6rem",
+                            "outline": "none",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="homo sapiens"
+                        <div
+                          key="11"
                         >
-                          <span
-                            className="icon icon-species"
-                            data-icon="H"
+                          <styled.div
+                            className=""
+                            key="111"
                             style={
                               Object {
-                                "color": "indianred",
+                                "display": "inline-block",
+                                "width": "100%",
                               }
                             }
-                            title="Homo sapiens"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=homo%20sapiens"
-                      >
-                        Homo sapiens
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="10 experiments-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        10 experiments
-                      </li>
-                      <li
-                        key="Baseline: 7-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=baseline"
-                        >
-                          Baseline: 7
-                        </a>
-                      </li>
-                      <li
-                        key="Differential: 3-2"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=homo%20sapiens&experimentType=differential"
-                        >
-                          Differential: 3
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
-              </div>
-            </StyledComponent>
-          </styled.div>
-          <styled.div
-            className=""
-            key="1"
-          >
-            <StyledComponent
-              className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-bxivhb",
-                    "isStatic": true,
-                    "lastClassName": "hfBy",
-                    "rules": Array [
-                      "
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className=""
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bxivhb",
+                                    "isStatic": true,
+                                    "lastClassName": "hfBy",
+                                    "rules": Array [
+                                      "
     /* border-radius: 8px; */
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-bxivhb",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-bxivhb hfBy"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "2 experiments",
-                      },
-                      Object {
-                        "text": "Differential: 2",
-                        "url": "http://localhost:8080/gxa/experiments?species=mus%20musculus&experimentType=differential",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Mus musculus",
-                      "url": "http://localhost:8080/gxa/experiments?species=mus%20musculus",
-                    }
-                  }
-                  iconSrc="mus musculus"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=mus%20musculus"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bxivhb",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="sc-bxivhb hfBy"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "2 experiments",
+                                      },
+                                      Object {
+                                        "text": "Differential: 2",
+                                        "url": "http://localhost:8080/gxa/experiments?species=mus%20musculus&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Mus musculus",
+                                      "url": "http://localhost:8080/gxa/experiments?species=mus%20musculus",
+                                    }
+                                  }
+                                  iconSrc="mus musculus"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=mus%20musculus"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="mus musculus"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="M"
+                                            style={
+                                              Object {
+                                                "color": "indianred",
+                                              }
+                                            }
+                                            title="Mus musculus"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=mus%20musculus"
+                                      >
+                                        Mus musculus
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="2 experiments-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        2 experiments
+                                      </li>
+                                      <li
+                                        key="Differential: 2-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=mus%20musculus&experimentType=differential"
+                                        >
+                                          Differential: 2
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={false}
+                        className="slick-slide slick-active"
+                        data-index={2}
+                        key="original2"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "fontSize": "6rem",
+                            "outline": "none",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="mus musculus"
+                        <div
+                          key="22"
                         >
-                          <span
-                            className="icon icon-species"
-                            data-icon="M"
+                          <styled.div
+                            className=""
+                            key="222"
                             style={
                               Object {
-                                "color": "indianred",
+                                "display": "inline-block",
+                                "width": "100%",
                               }
                             }
-                            title="Mus musculus"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=mus%20musculus"
-                      >
-                        Mus musculus
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="2 experiments-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        2 experiments
-                      </li>
-                      <li
-                        key="Differential: 2-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=mus%20musculus&experimentType=differential"
-                        >
-                          Differential: 2
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
-              </div>
-            </StyledComponent>
-          </styled.div>
-          <styled.div
-            className=""
-            key="2"
-          >
-            <StyledComponent
-              className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-bxivhb",
-                    "isStatic": true,
-                    "lastClassName": "hfBy",
-                    "rules": Array [
-                      "
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className=""
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bxivhb",
+                                    "isStatic": true,
+                                    "lastClassName": "hfBy",
+                                    "rules": Array [
+                                      "
     /* border-radius: 8px; */
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-bxivhb",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-bxivhb hfBy"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "1 experiment",
-                      },
-                      Object {
-                        "text": "Baseline: 1",
-                        "url": "http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni&experimentType=baseline",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Schistosoma mansoni",
-                      "url": "http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni",
-                    }
-                  }
-                  iconSrc="schistosoma mansoni"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bxivhb",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="sc-bxivhb hfBy"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Baseline: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni&experimentType=baseline",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Schistosoma mansoni",
+                                      "url": "http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni",
+                                    }
+                                  }
+                                  iconSrc="schistosoma mansoni"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="schistosoma mansoni"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="W"
+                                            style={
+                                              Object {
+                                                "color": "deepskyblue",
+                                              }
+                                            }
+                                            title="Schistosoma mansoni"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni"
+                                      >
+                                        Schistosoma mansoni
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Baseline: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni&experimentType=baseline"
+                                        >
+                                          Baseline: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={false}
+                        className="slick-slide slick-active"
+                        data-index={3}
+                        key="original3"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "fontSize": "6rem",
+                            "outline": "none",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="schistosoma mansoni"
+                        <div
+                          key="33"
                         >
-                          <span
-                            className="icon icon-species"
-                            data-icon="W"
+                          <styled.div
+                            className=""
+                            key="333"
                             style={
                               Object {
-                                "color": "deepskyblue",
+                                "display": "inline-block",
+                                "width": "100%",
                               }
                             }
-                            title="Schistosoma mansoni"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni"
-                      >
-                        Schistosoma mansoni
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="1 experiment-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        1 experiment
-                      </li>
-                      <li
-                        key="Baseline: 1-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=schistosoma%20mansoni&experimentType=baseline"
-                        >
-                          Baseline: 1
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
-              </div>
-            </StyledComponent>
-          </styled.div>
-          <styled.div
-            className=""
-            key="3"
-          >
-            <StyledComponent
-              className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-bxivhb",
-                    "isStatic": true,
-                    "lastClassName": "hfBy",
-                    "rules": Array [
-                      "
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className=""
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bxivhb",
+                                    "isStatic": true,
+                                    "lastClassName": "hfBy",
+                                    "rules": Array [
+                                      "
     /* border-radius: 8px; */
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-bxivhb",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-bxivhb hfBy"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "1 experiment",
-                      },
-                      Object {
-                        "text": "Differential: 1",
-                        "url": "http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster&experimentType=differential",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Drosophila melanogaster",
-                      "url": "http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster",
-                    }
-                  }
-                  iconSrc="drosophila melanogaster"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bxivhb",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="sc-bxivhb hfBy"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Differential: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Drosophila melanogaster",
+                                      "url": "http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster",
+                                    }
+                                  }
+                                  iconSrc="drosophila melanogaster"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="drosophila melanogaster"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="F"
+                                            style={
+                                              Object {
+                                                "color": "deepskyblue",
+                                              }
+                                            }
+                                            title="Drosophila melanogaster"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster"
+                                      >
+                                        Drosophila melanogaster
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Differential: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster&experimentType=differential"
+                                        >
+                                          Differential: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={false}
+                        className="slick-slide slick-active"
+                        data-index={4}
+                        key="original4"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "fontSize": "6rem",
+                            "outline": "none",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="drosophila melanogaster"
+                        <div
+                          key="44"
                         >
-                          <span
-                            className="icon icon-species"
-                            data-icon="F"
+                          <styled.div
+                            className=""
+                            key="444"
                             style={
                               Object {
-                                "color": "deepskyblue",
+                                "display": "inline-block",
+                                "width": "100%",
                               }
                             }
-                            title="Drosophila melanogaster"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster"
-                      >
-                        Drosophila melanogaster
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="1 experiment-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        1 experiment
-                      </li>
-                      <li
-                        key="Differential: 1-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=drosophila%20melanogaster&experimentType=differential"
-                        >
-                          Differential: 1
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
-              </div>
-            </StyledComponent>
-          </styled.div>
-          <styled.div
-            className=""
-            key="4"
-          >
-            <StyledComponent
-              className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-bxivhb",
-                    "isStatic": true,
-                    "lastClassName": "hfBy",
-                    "rules": Array [
-                      "
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className=""
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bxivhb",
+                                    "isStatic": true,
+                                    "lastClassName": "hfBy",
+                                    "rules": Array [
+                                      "
     /* border-radius: 8px; */
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-bxivhb",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-bxivhb hfBy"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "1 experiment",
-                      },
-                      Object {
-                        "text": "Differential: 1",
-                        "url": "http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos&experimentType=differential",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Anas platyrhynchos",
-                      "url": "http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos",
-                    }
-                  }
-                  iconSrc="anas platyrhynchos"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bxivhb",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="sc-bxivhb hfBy"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Differential: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Anas platyrhynchos",
+                                      "url": "http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos",
+                                    }
+                                  }
+                                  iconSrc="anas platyrhynchos"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="anas platyrhynchos"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="❔"
+                                            style={
+                                              Object {
+                                                "color": "black",
+                                              }
+                                            }
+                                            title="Anas platyrhynchos"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos"
+                                      >
+                                        Anas platyrhynchos
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Differential: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos&experimentType=differential"
+                                        >
+                                          Differential: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={false}
+                        className="slick-slide slick-active"
+                        data-index={5}
+                        key="original5"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "fontSize": "6rem",
+                            "outline": "none",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="anas platyrhynchos"
+                        <div
+                          key="55"
                         >
-                          <span
-                            className="icon icon-species"
-                            data-icon="❔"
+                          <styled.div
+                            className=""
+                            key="555"
                             style={
                               Object {
-                                "color": "black",
+                                "display": "inline-block",
+                                "width": "100%",
                               }
                             }
-                            title="Anas platyrhynchos"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos"
-                      >
-                        Anas platyrhynchos
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="1 experiment-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        1 experiment
-                      </li>
-                      <li
-                        key="Differential: 1-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=anas%20platyrhynchos&experimentType=differential"
-                        >
-                          Differential: 1
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
-              </div>
-            </StyledComponent>
-          </styled.div>
-          <styled.div
-            className=""
-            key="5"
-          >
-            <StyledComponent
-              className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-bxivhb",
-                    "isStatic": true,
-                    "lastClassName": "hfBy",
-                    "rules": Array [
-                      "
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className=""
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bxivhb",
+                                    "isStatic": true,
+                                    "lastClassName": "hfBy",
+                                    "rules": Array [
+                                      "
     /* border-radius: 8px; */
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-bxivhb",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-bxivhb hfBy"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "1 experiment",
-                      },
-                      Object {
-                        "text": "Differential: 1",
-                        "url": "http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans&experimentType=differential",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Caenorhabditis elegans",
-                      "url": "http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans",
-                    }
-                  }
-                  iconSrc="caenorhabditis elegans"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
-                        style={
-                          Object {
-                            "fontSize": "6rem",
-                          }
-                        }
-                      >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="caenorhabditis elegans"
-                        >
-                          <span
-                            className="icon icon-species"
-                            data-icon="W"
-                            style={
-                              Object {
-                                "color": "deepskyblue",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bxivhb",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
                               }
-                            }
-                            title="Caenorhabditis elegans"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans"
-                      >
-                        Caenorhabditis elegans
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="1 experiment-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        1 experiment
-                      </li>
-                      <li
-                        key="Differential: 1-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans&experimentType=differential"
-                        >
-                          Differential: 1
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="sc-bxivhb hfBy"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Differential: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Caenorhabditis elegans",
+                                      "url": "http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans",
+                                    }
+                                  }
+                                  iconSrc="caenorhabditis elegans"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="caenorhabditis elegans"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="W"
+                                            style={
+                                              Object {
+                                                "color": "deepskyblue",
+                                              }
+                                            }
+                                            title="Caenorhabditis elegans"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans"
+                                      >
+                                        Caenorhabditis elegans
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Differential: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=caenorhabditis%20elegans&experimentType=differential"
+                                        >
+                                          Differential: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                    </div>
+                  </Track>
+                </div>
               </div>
-            </StyledComponent>
-          </styled.div>
+            </InnerSlider>
+          </Slider>
         </div>
-      </ResponsiveCardsRow>
+      </CarousleCardsRow>
     </div>
     <div
       className="tabs-panel"
       id="plants"
       key="1"
     >
-      <ResponsiveCardsRow
+      <CarousleCardsRow
         CardClass={[Function]}
         cardContainerClassName=""
         cards={
@@ -1398,485 +1776,743 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
         className=""
         hoverColour="AliceBlue"
         imageIconHeight="2rem"
+        slideSettings={
+          Object {
+            "autoplay": true,
+            "autoplaySpeed": 2000,
+            "dots": true,
+            "infinite": true,
+            "slidesToScroll": 1,
+            "slidesToShow": 1,
+            "speed": 500,
+          }
+        }
         speciesIconHeight="6rem"
       >
         <div
           className=""
         >
-          <styled.div
-            className=""
-            key="0"
+          <Slider
+            autoplay={true}
+            autoplaySpeed={2000}
+            dots={true}
+            id="slide"
+            infinite={true}
+            slidesToScroll={1}
+            slidesToShow={3}
+            speed={500}
           >
-            <StyledComponent
+            <InnerSlider
+              accessibility={true}
+              adaptiveHeight={false}
+              afterChange={null}
+              appendDots={[Function]}
+              arrows={true}
+              autoplay={true}
+              autoplaySpeed={2000}
+              beforeChange={null}
+              centerMode={false}
+              centerPadding="50px"
               className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-ifAKCX",
-                    "isStatic": true,
-                    "lastClassName": "iAfeJP",
-                    "rules": Array [
-                      "
+              cssEase="ease"
+              customPaging={[Function]}
+              dots={true}
+              dotsClass="slick-dots"
+              draggable={true}
+              easing="linear"
+              edgeFriction={0.35}
+              fade={false}
+              focusOnSelect={false}
+              id="slide"
+              infinite={true}
+              initialSlide={0}
+              lazyLoad={null}
+              nextArrow={null}
+              onEdge={null}
+              onInit={null}
+              onLazyLoadError={null}
+              onReInit={null}
+              pauseOnDotsHover={false}
+              pauseOnFocus={false}
+              pauseOnHover={true}
+              prevArrow={null}
+              responsive={null}
+              rows={1}
+              rtl={false}
+              slide="div"
+              slidesPerRow={1}
+              slidesToScroll={1}
+              slidesToShow={3}
+              speed={500}
+              swipe={true}
+              swipeEvent={null}
+              swipeToSlide={false}
+              touchMove={true}
+              touchThreshold={5}
+              unslick={true}
+              useCSS={true}
+              useTransform={true}
+              variableWidth={false}
+              vertical={false}
+              waitForAnimate={true}
+            >
+              <div
+                className="slick-slider slick-initialized"
+              >
+                <div
+                  className="slick-list"
+                >
+                  <Track
+                    centerMode={false}
+                    centerPadding="50px"
+                    cssEase="ease"
+                    currentSlide={0}
+                    fade={false}
+                    focusOnSelect={null}
+                    infinite={true}
+                    lazyLoad={null}
+                    lazyLoadedList={Array []}
+                    listHeight={0}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                    rtl={false}
+                    slideCount={3}
+                    slideHeight={0}
+                    slideWidth={0}
+                    slidesToScroll={1}
+                    slidesToShow={3}
+                    speed={500}
+                    trackStyle={
+                      Object {
+                        "WebkitTransform": "translate3d(0px, 0px, 0px)",
+                        "WebkitTransition": "",
+                        "msTransform": "translateX(0px)",
+                        "opacity": 1,
+                        "transform": "translate3d(0px, 0px, 0px)",
+                        "transition": "",
+                      }
+                    }
+                    unslick={true}
+                    variableWidth={false}
+                    vertical={false}
+                  >
+                    <div
+                      className="slick-track"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                      style={
+                        Object {
+                          "WebkitTransform": "translate3d(0px, 0px, 0px)",
+                          "WebkitTransition": "",
+                          "msTransform": "translateX(0px)",
+                          "opacity": 1,
+                          "transform": "translate3d(0px, 0px, 0px)",
+                          "transition": "",
+                        }
+                      }
+                    >
+                      <div
+                        aria-hidden={false}
+                        className="slick-slide slick-active slick-current"
+                        data-index={0}
+                        key="original0"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "outline": "none",
+                            "width": 0,
+                          }
+                        }
+                        tabIndex="-1"
+                      >
+                        <div
+                          key="0"
+                        >
+                          <styled.div
+                            className=""
+                            key="0"
+                            style={
+                              Object {
+                                "display": "inline-block",
+                                "width": "100%",
+                              }
+                            }
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className=""
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-ifAKCX",
+                                    "isStatic": true,
+                                    "lastClassName": "iAfeJP",
+                                    "rules": Array [
+                                      "
     /* border-radius: 8px; */
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-ifAKCX",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-ifAKCX iAfeJP"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "3 experiments",
-                      },
-                      Object {
-                        "text": "Differential: 3",
-                        "url": "http://localhost:8080/gxa/experiments?species=oryza%20sativa&experimentType=differential",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Oryza sativa",
-                      "url": "http://localhost:8080/gxa/experiments?species=oryza%20sativa",
-                    }
-                  }
-                  iconSrc="oryza sativa"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=oryza%20sativa"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-ifAKCX",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="sc-ifAKCX iAfeJP"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "3 experiments",
+                                      },
+                                      Object {
+                                        "text": "Differential: 3",
+                                        "url": "http://localhost:8080/gxa/experiments?species=oryza%20sativa&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Oryza sativa",
+                                      "url": "http://localhost:8080/gxa/experiments?species=oryza%20sativa",
+                                    }
+                                  }
+                                  iconSrc="oryza sativa"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=oryza%20sativa"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="oryza sativa"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="6"
+                                            style={
+                                              Object {
+                                                "color": "mediumseagreen",
+                                              }
+                                            }
+                                            title="Oryza sativa"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=oryza%20sativa"
+                                      >
+                                        Oryza sativa
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="3 experiments-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        3 experiments
+                                      </li>
+                                      <li
+                                        key="Differential: 3-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=oryza%20sativa&experimentType=differential"
+                                        >
+                                          Differential: 3
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={false}
+                        className="slick-slide slick-active"
+                        data-index={1}
+                        key="original1"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "fontSize": "6rem",
+                            "outline": "none",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="oryza sativa"
+                        <div
+                          key="11"
                         >
-                          <span
-                            className="icon icon-species"
-                            data-icon="6"
+                          <styled.div
+                            className=""
+                            key="111"
                             style={
                               Object {
-                                "color": "mediumseagreen",
+                                "display": "inline-block",
+                                "width": "100%",
                               }
                             }
-                            title="Oryza sativa"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=oryza%20sativa"
-                      >
-                        Oryza sativa
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="3 experiments-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        3 experiments
-                      </li>
-                      <li
-                        key="Differential: 3-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=oryza%20sativa&experimentType=differential"
-                        >
-                          Differential: 3
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
-              </div>
-            </StyledComponent>
-          </styled.div>
-          <styled.div
-            className=""
-            key="1"
-          >
-            <StyledComponent
-              className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-ifAKCX",
-                    "isStatic": true,
-                    "lastClassName": "iAfeJP",
-                    "rules": Array [
-                      "
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className=""
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-ifAKCX",
+                                    "isStatic": true,
+                                    "lastClassName": "iAfeJP",
+                                    "rules": Array [
+                                      "
     /* border-radius: 8px; */
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-ifAKCX",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-ifAKCX iAfeJP"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "2 experiments",
-                      },
-                      Object {
-                        "text": "Differential: 2",
-                        "url": "http://localhost:8080/gxa/experiments?species=zea%20mays&experimentType=differential",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Zea mays",
-                      "url": "http://localhost:8080/gxa/experiments?species=zea%20mays",
-                    }
-                  }
-                  iconSrc="zea mays"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=zea%20mays"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-ifAKCX",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="sc-ifAKCX iAfeJP"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "2 experiments",
+                                      },
+                                      Object {
+                                        "text": "Differential: 2",
+                                        "url": "http://localhost:8080/gxa/experiments?species=zea%20mays&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Zea mays",
+                                      "url": "http://localhost:8080/gxa/experiments?species=zea%20mays",
+                                    }
+                                  }
+                                  iconSrc="zea mays"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=zea%20mays"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="zea mays"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="c"
+                                            style={
+                                              Object {
+                                                "color": "mediumseagreen",
+                                              }
+                                            }
+                                            title="Zea mays"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=zea%20mays"
+                                      >
+                                        Zea mays
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="2 experiments-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        2 experiments
+                                      </li>
+                                      <li
+                                        key="Differential: 2-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=zea%20mays&experimentType=differential"
+                                        >
+                                          Differential: 2
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden={false}
+                        className="slick-slide slick-active"
+                        data-index={2}
+                        key="original2"
+                        onClick={[Function]}
                         style={
                           Object {
-                            "fontSize": "6rem",
+                            "outline": "none",
+                            "width": 0,
                           }
                         }
+                        tabIndex="-1"
                       >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="zea mays"
+                        <div
+                          key="22"
                         >
-                          <span
-                            className="icon icon-species"
-                            data-icon="c"
+                          <styled.div
+                            className=""
+                            key="222"
                             style={
                               Object {
-                                "color": "mediumseagreen",
+                                "display": "inline-block",
+                                "width": "100%",
                               }
                             }
-                            title="Zea mays"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=zea%20mays"
-                      >
-                        Zea mays
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="2 experiments-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        2 experiments
-                      </li>
-                      <li
-                        key="Differential: 2-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=zea%20mays&experimentType=differential"
-                        >
-                          Differential: 2
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
-              </div>
-            </StyledComponent>
-          </styled.div>
-          <styled.div
-            className=""
-            key="2"
-          >
-            <StyledComponent
-              className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-ifAKCX",
-                    "isStatic": true,
-                    "lastClassName": "iAfeJP",
-                    "rules": Array [
-                      "
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className=""
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-ifAKCX",
+                                    "isStatic": true,
+                                    "lastClassName": "iAfeJP",
+                                    "rules": Array [
+                                      "
     /* border-radius: 8px; */
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-ifAKCX",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-ifAKCX iAfeJP"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "1 experiment",
-                      },
-                      Object {
-                        "text": "Baseline: 1",
-                        "url": "http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon&experimentType=baseline",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Brachypodium distachyon",
-                      "url": "http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon",
-                    }
-                  }
-                  iconSrc="brachypodium distachyon"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
-                        style={
-                          Object {
-                            "fontSize": "6rem",
-                          }
-                        }
-                      >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="brachypodium distachyon"
-                        >
-                          <span
-                            className="icon icon-species"
-                            data-icon="%"
-                            style={
-                              Object {
-                                "color": "mediumseagreen",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-ifAKCX",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
                               }
-                            }
-                            title="Brachypodium distachyon"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon"
-                      >
-                        Brachypodium distachyon
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="1 experiment-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        1 experiment
-                      </li>
-                      <li
-                        key="Baseline: 1-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon&experimentType=baseline"
-                        >
-                          Baseline: 1
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="sc-ifAKCX iAfeJP"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Baseline: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon&experimentType=baseline",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Brachypodium distachyon",
+                                      "url": "http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon",
+                                    }
+                                  }
+                                  iconSrc="brachypodium distachyon"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="brachypodium distachyon"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="%"
+                                            style={
+                                              Object {
+                                                "color": "mediumseagreen",
+                                              }
+                                            }
+                                            title="Brachypodium distachyon"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon"
+                                      >
+                                        Brachypodium distachyon
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Baseline: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=brachypodium%20distachyon&experimentType=baseline"
+                                        >
+                                          Baseline: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                    </div>
+                  </Track>
+                </div>
               </div>
-            </StyledComponent>
-          </styled.div>
+            </InnerSlider>
+          </Slider>
         </div>
-      </ResponsiveCardsRow>
+      </CarousleCardsRow>
     </div>
     <div
       className="tabs-panel"
       id="fungi"
       key="2"
     >
-      <ResponsiveCardsRow
+      <CarousleCardsRow
         CardClass={[Function]}
         cardContainerClassName=""
         cards={
@@ -1903,168 +2539,346 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
         className=""
         hoverColour="AliceBlue"
         imageIconHeight="2rem"
+        slideSettings={
+          Object {
+            "autoplay": true,
+            "autoplaySpeed": 2000,
+            "dots": true,
+            "infinite": true,
+            "slidesToScroll": 1,
+            "slidesToShow": 1,
+            "speed": 500,
+          }
+        }
         speciesIconHeight="6rem"
       >
         <div
           className=""
         >
-          <styled.div
-            className=""
-            key="0"
+          <Slider
+            autoplay={true}
+            autoplaySpeed={2000}
+            dots={true}
+            id="slide"
+            infinite={true}
+            slidesToScroll={1}
+            slidesToShow={1}
+            speed={500}
           >
-            <StyledComponent
+            <InnerSlider
+              accessibility={true}
+              adaptiveHeight={false}
+              afterChange={null}
+              appendDots={[Function]}
+              arrows={true}
+              autoplay={true}
+              autoplaySpeed={2000}
+              beforeChange={null}
+              centerMode={false}
+              centerPadding="50px"
               className=""
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "sc-EHOje",
-                    "isStatic": true,
-                    "lastClassName": "hWjXNE",
-                    "rules": Array [
-                      "
+              cssEase="ease"
+              customPaging={[Function]}
+              dots={true}
+              dotsClass="slick-dots"
+              draggable={true}
+              easing="linear"
+              edgeFriction={0.35}
+              fade={false}
+              focusOnSelect={false}
+              id="slide"
+              infinite={true}
+              initialSlide={0}
+              lazyLoad={null}
+              nextArrow={null}
+              onEdge={null}
+              onInit={null}
+              onLazyLoadError={null}
+              onReInit={null}
+              pauseOnDotsHover={false}
+              pauseOnFocus={false}
+              pauseOnHover={true}
+              prevArrow={null}
+              responsive={null}
+              rows={1}
+              rtl={false}
+              slide="div"
+              slidesPerRow={1}
+              slidesToScroll={1}
+              slidesToShow={1}
+              speed={500}
+              swipe={true}
+              swipeEvent={null}
+              swipeToSlide={false}
+              touchMove={true}
+              touchThreshold={5}
+              unslick={true}
+              useCSS={true}
+              useTransform={true}
+              variableWidth={false}
+              vertical={false}
+              waitForAnimate={true}
+            >
+              <div
+                className="slick-slider slick-initialized"
+              >
+                <div
+                  className="slick-list"
+                >
+                  <Track
+                    centerMode={false}
+                    centerPadding="50px"
+                    cssEase="ease"
+                    currentSlide={0}
+                    fade={false}
+                    focusOnSelect={null}
+                    infinite={true}
+                    lazyLoad={null}
+                    lazyLoadedList={Array []}
+                    listHeight={0}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseOver={[Function]}
+                    rtl={false}
+                    slideCount={1}
+                    slideHeight={0}
+                    slideWidth={0}
+                    slidesToScroll={1}
+                    slidesToShow={1}
+                    speed={500}
+                    trackStyle={
+                      Object {
+                        "WebkitTransform": "translate3d(0px, 0px, 0px)",
+                        "WebkitTransition": "",
+                        "msTransform": "translateX(0px)",
+                        "opacity": 1,
+                        "transform": "translate3d(0px, 0px, 0px)",
+                        "transition": "",
+                      }
+                    }
+                    unslick={true}
+                    variableWidth={false}
+                    vertical={false}
+                  >
+                    <div
+                      className="slick-track"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseOver={[Function]}
+                      style={
+                        Object {
+                          "WebkitTransform": "translate3d(0px, 0px, 0px)",
+                          "WebkitTransition": "",
+                          "msTransform": "translateX(0px)",
+                          "opacity": 1,
+                          "transform": "translate3d(0px, 0px, 0px)",
+                          "transition": "",
+                        }
+                      }
+                    >
+                      <div
+                        aria-hidden={false}
+                        className="slick-slide slick-active slick-current"
+                        data-index={0}
+                        key="original0"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "outline": "none",
+                            "width": 0,
+                          }
+                        }
+                        tabIndex="-1"
+                      >
+                        <div
+                          key="0"
+                        >
+                          <styled.div
+                            className=""
+                            key="0"
+                            style={
+                              Object {
+                                "display": "inline-block",
+                                "width": "100%",
+                              }
+                            }
+                            tabIndex={-1}
+                          >
+                            <StyledComponent
+                              className=""
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-EHOje",
+                                    "isStatic": true,
+                                    "lastClassName": "hWjXNE",
+                                    "rules": Array [
+                                      "
     /* border-radius: 8px; */
     :hover {
       background: ",
-                      "AliceBlue",
-                      ";
+                                      "AliceBlue",
+                                      ";
     }
   ",
-                    ],
-                  },
-                  "displayName": "styled.div",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "sc-EHOje",
-                  "target": "div",
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-            >
-              <div
-                className="sc-EHOje hWjXNE"
-              >
-                <Card
-                  content={
-                    Array [
-                      Object {
-                        "text": "1 experiment",
-                      },
-                      Object {
-                        "text": "Differential: 1",
-                        "url": "http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae&experimentType=differential",
-                      },
-                    ]
-                  }
-                  description={
-                    Object {
-                      "text": "Saccharomyces cerevisiae",
-                      "url": "http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae",
-                    }
-                  }
-                  iconSrc="saccharomyces cerevisiae"
-                  iconType="species"
-                  imageIconHeight="2rem"
-                  speciesIconHeight="6rem"
-                >
-                  <div
-                    style={
-                      Object {
-                        "marginBottom": 0,
-                        "paddingBottom": "2rem",
-                        "textAlign": "center",
-                      }
-                    }
-                  >
-                    <a
-                      href="http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae"
-                      style={
-                        Object {
-                          "borderBottom": 0,
-                        }
-                      }
-                    >
-                      <span
-                        style={
-                          Object {
-                            "fontSize": "6rem",
-                          }
-                        }
-                      >
-                        <EbiSpeciesIcon
-                          groupColors={
-                            Object {
-                              "other": "deepskyblue",
-                              "plants": "mediumseagreen",
-                              "warmBlooded": "indianred",
-                            }
-                          }
-                          species="saccharomyces cerevisiae"
-                        >
-                          <span
-                            className="icon icon-species"
-                            data-icon="Y"
-                            style={
-                              Object {
-                                "color": "deepskyblue",
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-EHOje",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
                               }
-                            }
-                            title="Saccharomyces cerevisiae"
-                          />
-                        </EbiSpeciesIcon>
-                      </span>
-                    </a>
-                    <h5>
-                      <a
-                        href="http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae"
-                      >
-                        Saccharomyces cerevisiae
-                      </a>
-                    </h5>
-                    <ul
-                      style={
-                        Object {
-                          "listStyle": "none",
-                          "marginLeft": 0,
-                        }
-                      }
-                    >
-                      <li
-                        key="1 experiment-0"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        1 experiment
-                      </li>
-                      <li
-                        key="Differential: 1-1"
-                        style={
-                          Object {
-                            "marginBottom": "0.3rem",
-                          }
-                        }
-                      >
-                        <a
-                          href="http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae&experimentType=differential"
-                        >
-                          Differential: 1
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </Card>
+                              forwardedRef={null}
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "width": "100%",
+                                }
+                              }
+                              tabIndex={-1}
+                            >
+                              <div
+                                className="sc-EHOje hWjXNE"
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                    "width": "100%",
+                                  }
+                                }
+                                tabIndex={-1}
+                              >
+                                <Card
+                                  content={
+                                    Array [
+                                      Object {
+                                        "text": "1 experiment",
+                                      },
+                                      Object {
+                                        "text": "Differential: 1",
+                                        "url": "http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae&experimentType=differential",
+                                      },
+                                    ]
+                                  }
+                                  description={
+                                    Object {
+                                      "text": "Saccharomyces cerevisiae",
+                                      "url": "http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae",
+                                    }
+                                  }
+                                  iconSrc="saccharomyces cerevisiae"
+                                  iconType="species"
+                                  imageIconHeight="2rem"
+                                  speciesIconHeight="6rem"
+                                >
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginBottom": 0,
+                                        "paddingBottom": "2rem",
+                                        "textAlign": "center",
+                                      }
+                                    }
+                                  >
+                                    <a
+                                      href="http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae"
+                                      style={
+                                        Object {
+                                          "borderBottom": 0,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "fontSize": "6rem",
+                                          }
+                                        }
+                                      >
+                                        <EbiSpeciesIcon
+                                          groupColors={
+                                            Object {
+                                              "other": "deepskyblue",
+                                              "plants": "mediumseagreen",
+                                              "warmBlooded": "indianred",
+                                            }
+                                          }
+                                          species="saccharomyces cerevisiae"
+                                        >
+                                          <span
+                                            className="icon icon-species"
+                                            data-icon="Y"
+                                            style={
+                                              Object {
+                                                "color": "deepskyblue",
+                                              }
+                                            }
+                                            title="Saccharomyces cerevisiae"
+                                          />
+                                        </EbiSpeciesIcon>
+                                      </span>
+                                    </a>
+                                    <h5>
+                                      <a
+                                        href="http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae"
+                                      >
+                                        Saccharomyces cerevisiae
+                                      </a>
+                                    </h5>
+                                    <ul
+                                      style={
+                                        Object {
+                                          "listStyle": "none",
+                                          "marginLeft": 0,
+                                        }
+                                      }
+                                    >
+                                      <li
+                                        key="1 experiment-0"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        1 experiment
+                                      </li>
+                                      <li
+                                        key="Differential: 1-1"
+                                        style={
+                                          Object {
+                                            "marginBottom": "0.3rem",
+                                          }
+                                        }
+                                      >
+                                        <a
+                                          href="http://localhost:8080/gxa/experiments?species=saccharomyces%20cerevisiae&experimentType=differential"
+                                        >
+                                          Differential: 1
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </Card>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </div>
+                      </div>
+                    </div>
+                  </Track>
+                </div>
               </div>
-            </StyledComponent>
-          </styled.div>
+            </InnerSlider>
+          </Slider>
         </div>
-      </ResponsiveCardsRow>
+      </CarousleCardsRow>
     </div>
   </div>
 </SpeciesSummaryPanel>

--- a/__test__/__snapshots__/SpeciesSummaryPanel.test.js.snap
+++ b/__test__/__snapshots__/SpeciesSummaryPanel.test.js.snap
@@ -260,7 +260,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
       id="animals"
       key="0"
     >
-      <CarousleCardsRow
+      <CarouselCardsRow
         CardClass={[Function]}
         cardContainerClassName=""
         cards={
@@ -392,11 +392,11 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
         <div
           className=""
         >
+          <GlobalStyleComponent />
           <Slider
             autoplay={true}
             autoplaySpeed={2000}
             dots={true}
-            id="slide"
             infinite={true}
             slidesToScroll={1}
             slidesToShow={6}
@@ -423,7 +423,6 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
               edgeFriction={0.35}
               fade={false}
               focusOnSelect={false}
-              id="slide"
               infinite={true}
               initialSlide={0}
               lazyLoad={null}
@@ -550,10 +549,9 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                                   "componentStyle": ComponentStyle {
                                     "componentId": "sc-bxivhb",
                                     "isStatic": true,
-                                    "lastClassName": "hfBy",
+                                    "lastClassName": "gxCHar",
                                     "rules": Array [
                                       "
-    /* border-radius: 8px; */
     :hover {
       background: ",
                                       "AliceBlue",
@@ -582,7 +580,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                               tabIndex={-1}
                             >
                               <div
-                                className="sc-bxivhb hfBy"
+                                className="sc-bxivhb gxCHar"
                                 style={
                                   Object {
                                     "display": "inline-block",
@@ -763,10 +761,9 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                                   "componentStyle": ComponentStyle {
                                     "componentId": "sc-bxivhb",
                                     "isStatic": true,
-                                    "lastClassName": "hfBy",
+                                    "lastClassName": "gxCHar",
                                     "rules": Array [
                                       "
-    /* border-radius: 8px; */
     :hover {
       background: ",
                                       "AliceBlue",
@@ -795,7 +792,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                               tabIndex={-1}
                             >
                               <div
-                                className="sc-bxivhb hfBy"
+                                className="sc-bxivhb gxCHar"
                                 style={
                                   Object {
                                     "display": "inline-block",
@@ -958,10 +955,9 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                                   "componentStyle": ComponentStyle {
                                     "componentId": "sc-bxivhb",
                                     "isStatic": true,
-                                    "lastClassName": "hfBy",
+                                    "lastClassName": "gxCHar",
                                     "rules": Array [
                                       "
-    /* border-radius: 8px; */
     :hover {
       background: ",
                                       "AliceBlue",
@@ -990,7 +986,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                               tabIndex={-1}
                             >
                               <div
-                                className="sc-bxivhb hfBy"
+                                className="sc-bxivhb gxCHar"
                                 style={
                                   Object {
                                     "display": "inline-block",
@@ -1153,10 +1149,9 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                                   "componentStyle": ComponentStyle {
                                     "componentId": "sc-bxivhb",
                                     "isStatic": true,
-                                    "lastClassName": "hfBy",
+                                    "lastClassName": "gxCHar",
                                     "rules": Array [
                                       "
-    /* border-radius: 8px; */
     :hover {
       background: ",
                                       "AliceBlue",
@@ -1185,7 +1180,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                               tabIndex={-1}
                             >
                               <div
-                                className="sc-bxivhb hfBy"
+                                className="sc-bxivhb gxCHar"
                                 style={
                                   Object {
                                     "display": "inline-block",
@@ -1348,10 +1343,9 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                                   "componentStyle": ComponentStyle {
                                     "componentId": "sc-bxivhb",
                                     "isStatic": true,
-                                    "lastClassName": "hfBy",
+                                    "lastClassName": "gxCHar",
                                     "rules": Array [
                                       "
-    /* border-radius: 8px; */
     :hover {
       background: ",
                                       "AliceBlue",
@@ -1380,7 +1374,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                               tabIndex={-1}
                             >
                               <div
-                                className="sc-bxivhb hfBy"
+                                className="sc-bxivhb gxCHar"
                                 style={
                                   Object {
                                     "display": "inline-block",
@@ -1543,10 +1537,9 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                                   "componentStyle": ComponentStyle {
                                     "componentId": "sc-bxivhb",
                                     "isStatic": true,
-                                    "lastClassName": "hfBy",
+                                    "lastClassName": "gxCHar",
                                     "rules": Array [
                                       "
-    /* border-radius: 8px; */
     :hover {
       background: ",
                                       "AliceBlue",
@@ -1575,7 +1568,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                               tabIndex={-1}
                             >
                               <div
-                                className="sc-bxivhb hfBy"
+                                className="sc-bxivhb gxCHar"
                                 style={
                                   Object {
                                     "display": "inline-block",
@@ -1708,14 +1701,14 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
             </InnerSlider>
           </Slider>
         </div>
-      </CarousleCardsRow>
+      </CarouselCardsRow>
     </div>
     <div
       className="tabs-panel"
       id="plants"
       key="1"
     >
-      <CarousleCardsRow
+      <CarouselCardsRow
         CardClass={[Function]}
         cardContainerClassName=""
         cards={
@@ -1792,11 +1785,11 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
         <div
           className=""
         >
+          <GlobalStyleComponent />
           <Slider
             autoplay={true}
             autoplaySpeed={2000}
             dots={true}
-            id="slide"
             infinite={true}
             slidesToScroll={1}
             slidesToShow={3}
@@ -1823,7 +1816,6 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
               edgeFriction={0.35}
               fade={false}
               focusOnSelect={false}
-              id="slide"
               infinite={true}
               initialSlide={0}
               lazyLoad={null}
@@ -1950,10 +1942,9 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                                   "componentStyle": ComponentStyle {
                                     "componentId": "sc-ifAKCX",
                                     "isStatic": true,
-                                    "lastClassName": "iAfeJP",
+                                    "lastClassName": "gnXemY",
                                     "rules": Array [
                                       "
-    /* border-radius: 8px; */
     :hover {
       background: ",
                                       "AliceBlue",
@@ -1982,7 +1973,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                               tabIndex={-1}
                             >
                               <div
-                                className="sc-ifAKCX iAfeJP"
+                                className="sc-ifAKCX gnXemY"
                                 style={
                                   Object {
                                     "display": "inline-block",
@@ -2145,10 +2136,9 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                                   "componentStyle": ComponentStyle {
                                     "componentId": "sc-ifAKCX",
                                     "isStatic": true,
-                                    "lastClassName": "iAfeJP",
+                                    "lastClassName": "gnXemY",
                                     "rules": Array [
                                       "
-    /* border-radius: 8px; */
     :hover {
       background: ",
                                       "AliceBlue",
@@ -2177,7 +2167,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                               tabIndex={-1}
                             >
                               <div
-                                className="sc-ifAKCX iAfeJP"
+                                className="sc-ifAKCX gnXemY"
                                 style={
                                   Object {
                                     "display": "inline-block",
@@ -2340,10 +2330,9 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                                   "componentStyle": ComponentStyle {
                                     "componentId": "sc-ifAKCX",
                                     "isStatic": true,
-                                    "lastClassName": "iAfeJP",
+                                    "lastClassName": "gnXemY",
                                     "rules": Array [
                                       "
-    /* border-radius: 8px; */
     :hover {
       background: ",
                                       "AliceBlue",
@@ -2372,7 +2361,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                               tabIndex={-1}
                             >
                               <div
-                                className="sc-ifAKCX iAfeJP"
+                                className="sc-ifAKCX gnXemY"
                                 style={
                                   Object {
                                     "display": "inline-block",
@@ -2505,14 +2494,14 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
             </InnerSlider>
           </Slider>
         </div>
-      </CarousleCardsRow>
+      </CarouselCardsRow>
     </div>
     <div
       className="tabs-panel"
       id="fungi"
       key="2"
     >
-      <CarousleCardsRow
+      <CarouselCardsRow
         CardClass={[Function]}
         cardContainerClassName=""
         cards={
@@ -2555,11 +2544,11 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
         <div
           className=""
         >
+          <GlobalStyleComponent />
           <Slider
             autoplay={true}
             autoplaySpeed={2000}
             dots={true}
-            id="slide"
             infinite={true}
             slidesToScroll={1}
             slidesToShow={1}
@@ -2586,7 +2575,6 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
               edgeFriction={0.35}
               fade={false}
               focusOnSelect={false}
-              id="slide"
               infinite={true}
               initialSlide={0}
               lazyLoad={null}
@@ -2713,10 +2701,9 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                                   "componentStyle": ComponentStyle {
                                     "componentId": "sc-EHOje",
                                     "isStatic": true,
-                                    "lastClassName": "hWjXNE",
+                                    "lastClassName": "fHEUvF",
                                     "rules": Array [
                                       "
-    /* border-radius: 8px; */
     :hover {
       background: ",
                                       "AliceBlue",
@@ -2745,7 +2732,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
                               tabIndex={-1}
                             >
                               <div
-                                className="sc-EHOje hWjXNE"
+                                className="sc-EHOje fHEUvF"
                                 style={
                                   Object {
                                     "display": "inline-block",
@@ -2878,7 +2865,7 @@ exports[`SpeciesSummaryPanel renders correctly 1`] = `
             </InnerSlider>
           </Slider>
         </div>
-      </CarousleCardsRow>
+      </CarouselCardsRow>
     </div>
   </div>
 </SpeciesSummaryPanel>

--- a/__test__/matchMedia.js
+++ b/__test__/matchMedia.js
@@ -1,0 +1,11 @@
+'use strict'
+
+Object.defineProperty(window, 'matchMedia', {
+  value: () => ({
+    matches: false,
+    addListener: () => {},
+    removeListener: () => {}
+  })
+})
+
+module.exports = window

--- a/html/SpeciesSummaryPanelDemo.js
+++ b/html/SpeciesSummaryPanelDemo.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 
 import SpeciesSummaryPanel from '../src/SpeciesSummaryPanel'
-import withFetchLoader from 'atlas-react-fetch-loader'
+import { withFetchLoader } from 'atlas-react-fetch-loader'
 
 const FetchLoadSpeciesSummaryPanel = withFetchLoader(SpeciesSummaryPanel)
 

--- a/html/index.html
+++ b/html/index.html
@@ -8,6 +8,30 @@
 
   <link rel="stylesheet" href="http://localhost:8080/gxa/sc/resources/css/theme-atlas.css" type="text/css" media="all">
   <link rel="stylesheet" href="http://localhost:8080/gxa/sc/resources/css/atlas.css" type="text/css" media="all">
+
+  <link rel="stylesheet" type="text/css" charset="UTF-8" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.min.css" />
+  <link rel="stylesheet" type="text/css" charset="UTF-8" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css" />
+  <style type="text/css">
+    .slick-slide img {
+      margin: auto;
+    }
+    .slick-slider {
+      margin: 30px auto 50px;
+    }
+    .slick-prev:before {
+      color: #3497c5;
+    }
+
+    .slick-next:before{
+      color: #3497c5;
+    }
+    .slick-prev:hover {
+      color: #2f5767;
+    }
+    .slick-next:hover{
+      color: #2f5767;
+    }
+  </style>
 </head>
 
 <body>
@@ -27,7 +51,42 @@
     <!-- Set to http://localhost:8080/gxa/ or http://localhost:8080/gxa_sc/ -- Remember the trailing slash! -->
     <script>
       document.addEventListener('DOMContentLoaded', function(event) {
-        var columns = 6;
+        const columns = 100;
+        const slideSettings = {
+          dots: true,
+          infinite: true,
+          speed: 500,
+          slidesToShow: 6,
+          slidesToScroll: 6,
+          autoplay: true,
+          autoplaySpeed: 2000,
+          responsive: [
+            {
+              breakpoint: 1024,
+              settings: {
+                slidesToShow: 3,
+                slidesToScroll: 3,
+                infinite: true,
+                dots: true
+              }
+            },
+            {
+              breakpoint: 600,
+              settings: {
+                slidesToShow: 2,
+                slidesToScroll: 2
+              }
+            },
+            {
+              breakpoint: 480,
+              settings: {
+                slidesToShow: 1,
+                slidesToScroll: 1
+              }
+            }
+          ]
+        };
+
         speciesSummaryPanelDemo.render(
           {
             host: 'http://localhost:8080/gxa/',
@@ -36,9 +95,10 @@
               $('#ea-species').foundation();
               $('#ea-species').foundationExtendEBI();
             },
-            responsiveCardsRowProps: {
-              className: 'row expanded',
-              largeColumns: columns
+            carousleCardsRowProps: {
+              className: 'row expanded small-up-2 medium-up-3 large-up-6',
+              cardContainerClassName: 'column',
+              slideSettings: slideSettings
             }
           },
           'ea-species');
@@ -46,7 +106,7 @@
         speciesSummaryPanelDemo.render(
           {
             host: 'http://localhost:8080/gxa/sc/',
-            resource: 'json/species-summary',
+            resource: 'json/species-summary?limit=' + columns,
             onComponentDidMount: function() {
               $('#scea-species').foundation();
               $('#scea-species').foundationExtendEBI();

--- a/html/index.html
+++ b/html/index.html
@@ -11,27 +11,6 @@
 
   <link rel="stylesheet" type="text/css" charset="UTF-8" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.min.css" />
   <link rel="stylesheet" type="text/css" charset="UTF-8" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css" />
-  <style type="text/css">
-    .slick-slide img {
-      margin: auto;
-    }
-    .slick-slider {
-      margin: 30px auto 50px;
-    }
-    .slick-prev:before {
-      color: #3497c5;
-    }
-
-    .slick-next:before{
-      color: #3497c5;
-    }
-    .slick-prev:hover {
-      color: #2f5767;
-    }
-    .slick-next:hover{
-      color: #2f5767;
-    }
-  </style>
 </head>
 
 <body>

--- a/html/index.html
+++ b/html/index.html
@@ -74,7 +74,7 @@
               $('#ea-species').foundation();
               $('#ea-species').foundationExtendEBI();
             },
-            carousleCardsRowProps: {
+            carouselCardsRowProps: {
               className: 'row expanded small-up-2 medium-up-3 large-up-6',
               cardContainerClassName: 'column',
               slideSettings: slideSettings
@@ -84,11 +84,16 @@
 
         speciesSummaryPanelDemo.render(
           {
-            host: 'http://localhost:8080/gxa/sc/',
+            host: 'https://www.ebi.ac.uk/gxa/sc/',
             resource: 'json/species-summary?limit=' + columns,
             onComponentDidMount: function() {
               $('#scea-species').foundation();
               $('#scea-species').foundationExtendEBI();
+            },
+            carouselCardsRowProps: {
+              className: 'row expanded small-up-2 medium-up-3 large-up-6',
+              cardContainerClassName: 'column',
+              slideSettings: slideSettings
             }
           },
           'scea-species');

--- a/html/index.html
+++ b/html/index.html
@@ -31,7 +31,7 @@
     <script>
       document.addEventListener('DOMContentLoaded', function(event) {
         const columns = 100;
-        const slideSettings = {
+        const sliderSettings = {
           dots: true,
           infinite: true,
           speed: 500,
@@ -80,7 +80,7 @@
             carouselCardsRowProps: {
               className: 'row expanded small-up-2 medium-up-3 large-up-6',
               cardContainerClassName: 'column',
-              slideSettings: slideSettings
+              sliderSettings: sliderSettings
             }
           },
           'ea-species');
@@ -96,7 +96,9 @@
             carouselCardsRowProps: {
               className: 'row expanded small-up-2 medium-up-3 large-up-6',
               cardContainerClassName: 'column',
-              slideSettings: slideSettings
+              sliderSettings: sliderSettings,
+              containerHeight: `320px`,
+              sliderHeight: `300px`
             }
           },
           'scea-species');

--- a/html/index.html
+++ b/html/index.html
@@ -37,6 +37,7 @@
           speed: 500,
           slidesToShow: 6,
           slidesToScroll: 6,
+          adaptiveHeight: true,
           autoplay: true,
           autoplaySpeed: 2000,
           responsive: [
@@ -53,14 +54,16 @@
               breakpoint: 600,
               settings: {
                 slidesToShow: 2,
-                slidesToScroll: 2
+                slidesToScroll: 2,
+                dots: true
               }
             },
             {
               breakpoint: 480,
               settings: {
                 slidesToShow: 1,
-                slidesToScroll: 1
+                slidesToScroll: 1,
+                dots: true
               }
             }
           ]
@@ -84,7 +87,7 @@
 
         speciesSummaryPanelDemo.render(
           {
-            host: 'https://www.ebi.ac.uk/gxa/sc/',
+            host: 'https://www-test.ebi.ac.uk/gxa/sc/',
             resource: 'json/species-summary?limit=' + columns,
             onComponentDidMount: function() {
               $('#scea-species').foundation();

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -169,7 +168,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -849,7 +847,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
       "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
-      "dev": true,
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.11",
@@ -870,7 +867,6 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz",
       "integrity": "sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==",
-      "dev": true,
       "requires": {
         "@emotion/memoize": "0.7.1"
       }
@@ -878,14 +874,12 @@
     "@emotion/memoize": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.1.tgz",
-      "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==",
-      "dev": true
+      "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg=="
     },
     "@emotion/unitless": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.3.tgz",
-      "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg==",
-      "dev": true
+      "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg=="
     },
     "@jest/console": {
       "version": "24.7.1",
@@ -1734,7 +1728,9 @@
       "dev": true
     },
     "atlas-homepage-cards": {
-      "version": "file:../atlas-homepage-cards",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atlas-homepage-cards/-/atlas-homepage-cards-2.1.0.tgz",
+      "integrity": "sha512-puOJR5N9LBsjleo2XFRUVsXkmbS3aoJ2nkXJojqWsyPhfMx4aVOSf3UowZfPKVD7KAU2zuAUimciDFwy3Y7WUQ==",
       "requires": {
         "prop-types": "^15.7.2",
         "react": "^16.8.5",
@@ -1826,7 +1822,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz",
       "integrity": "sha512-sQVKG8irFXx14ZfaK1bBePirfkacl3j8nZwSZK+ZjsbnadRHKQTbhXbe/RB1vT6Vgkz45E+V95LBq4KqdhZUNw==",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
@@ -1837,8 +1832,7 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-      "dev": true
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-preset-jest": {
       "version": "24.6.0",
@@ -2282,8 +2276,7 @@
     "camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=",
-      "dev": true
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caniuse-lite": {
       "version": "1.0.30000967",
@@ -2416,6 +2409,11 @@
           }
         }
       }
+    },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "clean-webpack-plugin": {
       "version": "2.0.2",
@@ -2818,8 +2816,7 @@
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
-      "dev": true
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
     },
     "css-select": {
       "version": "1.2.0",
@@ -2837,7 +2834,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.1.tgz",
       "integrity": "sha512-yO+oEx1Lf+hDKasqQRVrAvzMCz825Huh1VMlEEDlRWyAhFb/FWb6I0KpEF1PkyKQ7NEdcx9d5M2ZEWgJAsgPvQ==",
-      "dev": true,
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -3278,6 +3274,11 @@
         "memory-fs": "^0.2.0",
         "tapable": "^0.1.8"
       }
+    },
+    "enquire.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
+      "integrity": "sha1-PoeAybi4NQhMP2DhZtvDwqPImBQ="
     },
     "entities": {
       "version": "1.1.2",
@@ -3797,8 +3798,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
@@ -5155,8 +5155,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -6500,6 +6499,14 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
+      "requires": {
+        "string-convert": "^0.2.0"
+      }
+    },
     "json3": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
@@ -6652,8 +6659,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash._baseisequal": {
       "version": "3.0.7",
@@ -6677,6 +6683,11 @@
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.escape": {
       "version": "4.0.1",
@@ -6848,8 +6859,7 @@
     "memoize-one": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz",
-      "integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA==",
-      "dev": true
+      "integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA=="
     },
     "memory-fs": {
       "version": "0.2.0",
@@ -7821,8 +7831,7 @@
     "postcss-value-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "dev": true
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -8105,10 +8114,33 @@
         "scheduler": "^0.13.6"
       }
     },
+    "react-ebi-species": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-ebi-species/-/react-ebi-species-2.2.1.tgz",
+      "integrity": "sha512-dOkdAciDkHvbo7+JvBdVBhiFLHxt+Vcw6tC2ALCdDXKVbUsmnRr8NFthpbLrJ+m6nUY2UT79C/dpvzDSxYM7hA==",
+      "requires": {
+        "prop-types": "^15.7.2",
+        "react": "^16.8.6",
+        "react-dom": "^16.8.6",
+        "styled-components": "^4.2.0"
+      }
+    },
     "react-is": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+    },
+    "react-slick": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.24.0.tgz",
+      "integrity": "sha512-Pvo0B74ohumQdYOf0qP+pdQpj9iUbAav7+2qiF3uTc5XeQp/Y/cnIeDBM2tB3txthfSe05jKIqLMJTS6qVvt5g==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "enquire.js": "^2.1.6",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
+      }
     },
     "react-test-renderer": {
       "version": "16.8.6",
@@ -8401,6 +8433,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.10.1",
@@ -9216,6 +9253,11 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
+    "string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c="
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -9305,7 +9347,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.2.0.tgz",
       "integrity": "sha512-L/LzkL3ZbBhqIVHdR7DbYujy4tqvTNRfc+4JWDCYyhTatI+8CRRQUmdaR0+ARl03DWsfKLhjewll5uNLrqrl4A==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@emotion/is-prop-valid": "^0.7.3",
@@ -9323,20 +9364,17 @@
     "stylis": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==",
-      "dev": true
+      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
     },
     "stylis-rule-sheet": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
-      "dev": true
+      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
     },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -9581,8 +9619,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -9876,8 +9913,7 @@
     "urijs": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
-      "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg==",
-      "dev": true
+      "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg=="
     },
     "urix": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -168,6 +169,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -847,6 +849,7 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
       "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+      "dev": true,
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.11",
@@ -867,6 +870,7 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz",
       "integrity": "sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==",
+      "dev": true,
       "requires": {
         "@emotion/memoize": "0.7.1"
       }
@@ -874,12 +878,14 @@
     "@emotion/memoize": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.1.tgz",
-      "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg=="
+      "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==",
+      "dev": true
     },
     "@emotion/unitless": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.3.tgz",
-      "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg=="
+      "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg==",
+      "dev": true
     },
     "@jest/console": {
       "version": "24.7.1",
@@ -1728,13 +1734,12 @@
       "dev": true
     },
     "atlas-homepage-cards": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/atlas-homepage-cards/-/atlas-homepage-cards-2.0.2.tgz",
-      "integrity": "sha512-6M2jp2K+8w6WbGvrULPkWzaGmAbGvs9W/+Lp7i0MuLeTSLTgZjdDlfaajoD/p2QgJWI1zpUQi96b8C4adLjVfQ==",
+      "version": "file:../atlas-homepage-cards",
       "requires": {
         "prop-types": "^15.7.2",
-        "react": "^16.8.6",
-        "react-ebi-species": "^2.2.1",
+        "react": "^16.8.5",
+        "react-ebi-species": "^2.2.0",
+        "react-slick": "^0.24.0",
         "styled-components": "^4.2.0",
         "urijs": "^1.19.1"
       }
@@ -1821,6 +1826,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz",
       "integrity": "sha512-sQVKG8irFXx14ZfaK1bBePirfkacl3j8nZwSZK+ZjsbnadRHKQTbhXbe/RB1vT6Vgkz45E+V95LBq4KqdhZUNw==",
+      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
@@ -1831,7 +1837,8 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+      "dev": true
     },
     "babel-preset-jest": {
       "version": "24.6.0",
@@ -2275,7 +2282,8 @@
     "camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=",
+      "dev": true
     },
     "caniuse-lite": {
       "version": "1.0.30000967",
@@ -2810,7 +2818,8 @@
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
+      "dev": true
     },
     "css-select": {
       "version": "1.2.0",
@@ -2828,6 +2837,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.1.tgz",
       "integrity": "sha512-yO+oEx1Lf+hDKasqQRVrAvzMCz825Huh1VMlEEDlRWyAhFb/FWb6I0KpEF1PkyKQ7NEdcx9d5M2ZEWgJAsgPvQ==",
+      "dev": true,
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -3787,7 +3797,8 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -5144,7 +5155,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -6640,7 +6652,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash._baseisequal": {
       "version": "3.0.7",
@@ -6835,7 +6848,8 @@
     "memoize-one": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz",
-      "integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA=="
+      "integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA==",
+      "dev": true
     },
     "memory-fs": {
       "version": "0.2.0",
@@ -7807,7 +7821,8 @@
     "postcss-value-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -8088,17 +8103,6 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.13.6"
-      }
-    },
-    "react-ebi-species": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-ebi-species/-/react-ebi-species-2.2.1.tgz",
-      "integrity": "sha512-dOkdAciDkHvbo7+JvBdVBhiFLHxt+Vcw6tC2ALCdDXKVbUsmnRr8NFthpbLrJ+m6nUY2UT79C/dpvzDSxYM7hA==",
-      "requires": {
-        "prop-types": "^15.7.2",
-        "react": "^16.8.6",
-        "react-dom": "^16.8.6",
-        "styled-components": "^4.2.0"
       }
     },
     "react-is": {
@@ -9301,6 +9305,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.2.0.tgz",
       "integrity": "sha512-L/LzkL3ZbBhqIVHdR7DbYujy4tqvTNRfc+4JWDCYyhTatI+8CRRQUmdaR0+ARl03DWsfKLhjewll5uNLrqrl4A==",
+      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@emotion/is-prop-valid": "^0.7.3",
@@ -9318,17 +9323,20 @@
     "stylis": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
+      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==",
+      "dev": true
     },
     "stylis-rule-sheet": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
+      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
+      "dev": true
     },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -9573,7 +9581,8 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -9867,7 +9876,8 @@
     "urijs": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
-      "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg=="
+      "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg==",
+      "dev": true
     },
     "urix": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "species-summary-panel",
-  "version": "1.0.0-snapshot",
+  "version": "1.0.0-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1728,9 +1728,9 @@
       "dev": true
     },
     "atlas-homepage-cards": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/atlas-homepage-cards/-/atlas-homepage-cards-2.1.0.tgz",
-      "integrity": "sha512-puOJR5N9LBsjleo2XFRUVsXkmbS3aoJ2nkXJojqWsyPhfMx4aVOSf3UowZfPKVD7KAU2zuAUimciDFwy3Y7WUQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atlas-homepage-cards/-/atlas-homepage-cards-2.1.2.tgz",
+      "integrity": "sha512-RySaY8/StRHeuoeTt4vLHhdzYjWt4xN3N5f4X3clRgVD6Dl9KGqJNeaUtFWYOEP++KBXko0OdbboX+5HiQTKPg==",
       "requires": {
         "prop-types": "^15.7.2",
         "react": "^16.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1728,16 +1728,36 @@
       "dev": true
     },
     "atlas-homepage-cards": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atlas-homepage-cards/-/atlas-homepage-cards-2.1.2.tgz",
-      "integrity": "sha512-RySaY8/StRHeuoeTt4vLHhdzYjWt4xN3N5f4X3clRgVD6Dl9KGqJNeaUtFWYOEP++KBXko0OdbboX+5HiQTKPg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/atlas-homepage-cards/-/atlas-homepage-cards-2.1.3.tgz",
+      "integrity": "sha512-F11apW/rqcbtwRRhxRNoP2gMsD4SToPh2T8xAx5S2Rm2mj+Ki9gazULRPsAR21X7nABXMUKff/Qg6UPAIfdiRA==",
       "requires": {
         "prop-types": "^15.7.2",
-        "react": "^16.8.5",
-        "react-ebi-species": "^2.2.0",
+        "react": "^16.8.6",
+        "react-ebi-species": "^2.2.1",
         "react-slick": "^0.24.0",
-        "styled-components": "^4.2.0",
+        "styled-components": "^4.2.1",
         "urijs": "^1.19.1"
+      },
+      "dependencies": {
+        "styled-components": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.2.1.tgz",
+          "integrity": "sha512-zBSMOJW1zfQ1rASGHJ5dHXIkn3VoOGLtQAYhkd4Ib7e+eI//uwMJWsI65JRe3aGrN2Xx8IT9jxxnVSXt9LaLCw==",
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@emotion/is-prop-valid": "^0.7.3",
+            "@emotion/unitless": "^0.7.0",
+            "babel-plugin-styled-components": ">= 1",
+            "css-to-react-native": "^2.2.2",
+            "memoize-one": "^5.0.0",
+            "prop-types": "^15.5.4",
+            "react-is": "^16.6.0",
+            "stylis": "^3.5.0",
+            "stylis-rule-sheet": "^0.0.10",
+            "supports-color": "^5.5.0"
+          }
+        }
       }
     },
     "atlas-react-fetch-loader": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/ebi-gene-expression-group/species-summary-panel"
   },
   "dependencies": {
-    "atlas-homepage-cards": "^2.1.0",
+    "atlas-homepage-cards": "^2.1.2",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/ebi-gene-expression-group/species-summary-panel"
   },
   "dependencies": {
-    "atlas-homepage-cards": "^2.1.2",
+    "atlas-homepage-cards": "^2.1.3",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
       "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js"
     },
     "setupFiles": [
-      "<rootDir>/__mocks__/requestAnimationFrame.js"
+      "<rootDir>/__mocks__/requestAnimationFrame.js",
+      "<rootDir>/__mocks__/matchMedia.js"
     ],
     "coveragePathIgnorePatterns": [
       "<rootDir>/__test__/TestUtils.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "species-summary-panel",
-  "version": "1.0.0-snapshot",
+  "version": "1.0.0-rc",
   "description": "Species summary panel to display in Expression Atlas and Single Cell Expression Atlas",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "species-summary-panel",
-  "version": "1.0.0-rc",
+  "version": "1.0.0-snapshot",
   "description": "Species summary panel to display in Expression Atlas and Single Cell Expression Atlas",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/ebi-gene-expression-group/species-summary-panel"
   },
   "dependencies": {
-    "atlas-homepage-cards": "^2.0.2",
+    "atlas-homepage-cards": "file:../atlas-homepage-cards",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/ebi-gene-expression-group/species-summary-panel"
   },
   "dependencies": {
-    "atlas-homepage-cards": "file:../atlas-homepage-cards",
+    "atlas-homepage-cards": "^2.1.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/src/SpeciesSummaryPanel.js
+++ b/src/SpeciesSummaryPanel.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import ResponsiveCardsRow from 'atlas-homepage-cards'
+import { CarousleCardsRow } from 'atlas-homepage-cards'
 
 const tabsId = `species-summary-tabs`
 
 class SpeciesSummaryPanel extends React.Component {
   render() {
-    const { speciesSummary, responsiveCardsRowProps } = this.props
+    const { speciesSummary, carousleCardsRowProps } = this.props
 
     return(
       [
@@ -24,9 +24,9 @@ class SpeciesSummaryPanel extends React.Component {
           {
             speciesSummary.map(({kingdom, cards}, idx) =>
               <div key={idx} className={`tabs-panel${idx === 0 ? ` is-active` : ``}`} id={kingdom}>
-                <ResponsiveCardsRow
+                <CarousleCardsRow
                   cards={cards}
-                  {...responsiveCardsRowProps}
+                  {...carousleCardsRowProps}
                 />
               </div>
             )
@@ -46,10 +46,10 @@ class SpeciesSummaryPanel extends React.Component {
 SpeciesSummaryPanel.propTypes = {
   speciesSummary: PropTypes.arrayOf(PropTypes.shape({
     kingdom: PropTypes.string.isRequired,
-    cards: ResponsiveCardsRow.propTypes.cards
+    cards: CarousleCardsRow.propTypes.cards
   })).isRequired,
   onComponentDidMount: PropTypes.func,
-  responsiveCardsRowProps: PropTypes.object
+  carousleCardsRowProps: PropTypes.object
 }
 
 SpeciesSummaryPanel.defaultProps = {

--- a/src/SpeciesSummaryPanel.js
+++ b/src/SpeciesSummaryPanel.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { CarousleCardsRow } from 'atlas-homepage-cards'
+import { CarouselCardsRow } from 'atlas-homepage-cards'
 
 const tabsId = `species-summary-tabs`
 
 class SpeciesSummaryPanel extends React.Component {
   render() {
-    const { speciesSummary, carousleCardsRowProps } = this.props
+    const { speciesSummary, carouselCardsRowProps } = this.props
 
     return(
       [
@@ -24,9 +24,9 @@ class SpeciesSummaryPanel extends React.Component {
           {
             speciesSummary.map(({kingdom, cards}, idx) =>
               <div key={idx} className={`tabs-panel${idx === 0 ? ` is-active` : ``}`} id={kingdom}>
-                <CarousleCardsRow
+                <CarouselCardsRow
                   cards={cards}
-                  {...carousleCardsRowProps}
+                  {...carouselCardsRowProps}
                 />
               </div>
             )
@@ -46,10 +46,10 @@ class SpeciesSummaryPanel extends React.Component {
 SpeciesSummaryPanel.propTypes = {
   speciesSummary: PropTypes.arrayOf(PropTypes.shape({
     kingdom: PropTypes.string.isRequired,
-    cards: CarousleCardsRow.propTypes.cards
+    cards: CarouselCardsRow.propTypes.cards
   })).isRequired,
   onComponentDidMount: PropTypes.func,
-  carousleCardsRowProps: PropTypes.object
+  carouselCardsRowProps: PropTypes.object
 }
 
 SpeciesSummaryPanel.defaultProps = {


### PR DESCRIPTION
This PR implements a local branch of [atlas-homepage-cards](https://github.com/ebi-gene-expression-group/atlas-homepage-cards/pull/12). Currently, neither single cell nor bulk are importing this repository as an npm package. Instead, they install a local module. Is there any reason for that? I think we could publish it after this merge.