### PR TITLE
Downgrade eslint-plugin-cypress for eslint-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-jest": "^28.1.1",
     "babel-loader": "^8.2.5",
     "eslint": "^8.17.0",
+    "eslint-plugin-cypress": "^3.6.0",
     "jest": "^28.1.1",
     "jest-environment-jsdom": "^28.1.1",
     "react-test-renderer": "^17.0.2",


### PR DESCRIPTION
We need to specify the package version to avoid eslint mistach while building node_modules from the parent repository `atlas-web-single-cell`.